### PR TITLE
Fold empty root nodes only if `manage_folds` is enabled

### DIFF
--- a/lua/aerial/data.lua
+++ b/lua/aerial/data.lua
@@ -1,4 +1,5 @@
 local util = require("aerial.util")
+local config = require("aerial.config")
 
 local BufData = {
   new = function(t)
@@ -59,7 +60,7 @@ local BufData = {
   end,
 
   is_collapsable = function(_, item)
-    return item.level == 0 or (item.children and not vim.tbl_isempty(item.children))
+    return (item.level == 0 and config.manage_folds) or (item.children and not vim.tbl_isempty(item.children))
   end,
 
   get_root_of = function(_, item)


### PR DESCRIPTION
I use Aerial purely for quick navigation with code folding functionality disabled. I tend to call `require("aerial").tree_close_all()` quite a lot. Seeing all the root nodes as being folded is a bit disorienting.

Calling `tree_close_all` with this change:
![image](https://user-images.githubusercontent.com/85341530/125999150-e1789d81-7bc8-4db1-a2d1-685df5285786.png)

Without:
![image](https://user-images.githubusercontent.com/85341530/125999305-e7defba1-5c24-4604-a8a2-e3600e6754ae.png)


This PR is just a proposal. If it doesn't suit Aerial's design, feel free to close it.