### PR TITLE
Add support for markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Command               | arg            | description
 ```lua
 vim.g.aerial = {
   -- Priority list of preferred backends for aerial
-  backends = { "lsp", "treesitter" },
+  backends = { "lsp", "treesitter", "markdown" },
 
   -- Enum: persist, close, auto, global
   --   persist - aerial window will stay open until closed
@@ -269,6 +269,11 @@ vim.g.aerial = {
   },
 
   treesitter = {
+    -- How long to wait (in ms) after a buffer change before updating
+    update_delay = 300,
+  },
+
+  markdown = {
     -- How long to wait (in ms) after a buffer change before updating
     update_delay = 300,
   },

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A code outline window for skimming and quick navigation
 * [Setup](#setup)
   * [LSP](#lsp)
   * [Treesitter](#treesitter)
+  * [Markdown](#markdown)
   * [Keymaps](#keymaps)
 * [Commands](#commands)
 * [Options](#options)
@@ -128,6 +129,13 @@ automatically fetch symbols from treesitter.
 Don't see your language here? [Request support for
 it](https://github.com/stevearc/aerial.nvim/issues/new?assignees=stevearc&labels=enhancement&template=feature-request--treesitter-language-.md&title=)
 </details>
+
+### Markdown
+
+Since it looks like it may be a while until we get a [treesitter parser for
+markdown](https://github.com/nvim-treesitter/nvim-treesitter/issues/872), there
+is a simple backend that does rudimentary parsing of markdown headers. It should
+work well enough in most cases.
 
 ### Keymaps
 

--- a/doc/aerial.txt
+++ b/doc/aerial.txt
@@ -230,6 +230,9 @@ g:aerial_lsp_update_when_errors                 *g:aerial_lsp_update_when_errors
 g:aerial_treesitter_update_delay               *g:aerial_treesitter_update_delay*
     How long to wait (in ms) after a buffer change before updating.
 
+g:aerial_markdown_update_delay                   *g:aerial_markdown_update_delay*
+    How long to wait (in ms) after a buffer change before updating.
+
 g:aerial_icons                                                   *g:aerial_icons*
     A map of |SymbolKind| to icons. You can also specify "<Symbol>Collapsed"
     to change the icon when the tree is collapsed at this symbol, or

--- a/doc/tags
+++ b/doc/tags
@@ -51,6 +51,7 @@ g:aerial_link_tree_to_folds	aerial.txt	/*g:aerial_link_tree_to_folds*
 g:aerial_lsp_diagnostics_trigger_update	aerial.txt	/*g:aerial_lsp_diagnostics_trigger_update*
 g:aerial_lsp_update_when_errors	aerial.txt	/*g:aerial_lsp_update_when_errors*
 g:aerial_manage_folds	aerial.txt	/*g:aerial_manage_folds*
+g:aerial_markdown_update_delay	aerial.txt	/*g:aerial_markdown_update_delay*
 g:aerial_max_width	aerial.txt	/*g:aerial_max_width*
 g:aerial_min_width	aerial.txt	/*g:aerial_min_width*
 g:aerial_nerd_font	aerial.txt	/*g:aerial_nerd_font*

--- a/lua/aerial/backends/markdown.lua
+++ b/lua/aerial/backends/markdown.lua
@@ -1,0 +1,57 @@
+local backends = require("aerial.backends")
+local util = require("aerial.backends.util")
+
+local M = {}
+
+M.is_supported = function(bufnr)
+  local filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
+  return filetype == "markdown"
+end
+
+M.fetch_symbols_sync = function(timeout)
+  local bufnr = 0
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
+  local items = {}
+  local stack = {}
+  for lnum, line in ipairs(lines) do
+    local idx, len = string.find(line, "^#+ ")
+    if idx == 1 then
+      local level = len - 2
+      local parent = stack[level]
+      local item = {
+        kind = "Interface",
+        name = string.sub(line, len + 1),
+        level = level,
+        parent = parent,
+        lnum = lnum,
+        col = 0,
+      }
+      if parent then
+        if not parent.children then
+          parent.children = {}
+        end
+        table.insert(parent.children, item)
+      else
+        table.insert(items, item)
+      end
+      while #stack > level and #stack > 0 do
+        table.remove(stack, #stack)
+      end
+      table.insert(stack, item)
+    end
+  end
+  backends.set_symbols(bufnr, items)
+end
+
+M.fetch_symbols = M.fetch_symbols_sync
+
+M.attach = function(bufnr)
+  util.add_change_watcher(bufnr, "markdown")
+  M.fetch_symbols()
+end
+
+M.detach = function(bufnr)
+  util.remove_change_watcher(bufnr, "markdown")
+end
+
+return M

--- a/lua/aerial/backends/util.lua
+++ b/lua/aerial/backends/util.lua
@@ -1,0 +1,64 @@
+local backends = require("aerial.backends")
+local config = require("aerial.config")
+local M = {}
+
+M.add_change_watcher = function(bufnr, backend_name)
+  if not bufnr or bufnr == 0 then
+    bufnr = vim.api.nvim_get_current_buf()
+  end
+  vim.cmd(string.format(
+    [[augroup Aerial%s
+      au! * <buffer=%d>
+      au TextChanged <buffer=%d> lua require'aerial.backends.util'._on_text_changed('%s')
+      au InsertLeave <buffer=%d> lua require'aerial.backends.util'._on_insert_leave('%s')
+    augroup END
+    ]],
+    backend_name,
+    bufnr,
+    bufnr,
+    backend_name,
+    bufnr,
+    backend_name
+  ))
+end
+
+M.remove_change_watcher = function(bufnr, backend_name)
+  vim.cmd(string.format(
+    [[augroup Aerial%s
+      au! * <buffer=%d>
+    augroup END
+    ]],
+    backend_name,
+    bufnr
+  ))
+end
+
+local timer = nil
+local function throttle_update(backend_name)
+  if timer or not backends.is_backend_attached(0, backend_name) then
+    return
+  end
+  timer = vim.loop.new_timer()
+  timer:start(
+    config[backend_name .. ".update_delay"] or 300,
+    0,
+    vim.schedule_wrap(function()
+      timer:close()
+      timer = nil
+      local backend = backends.get_backend_by_name(backend_name)
+      if backend then
+        backend.fetch_symbols()
+      end
+    end)
+  )
+end
+
+M._on_text_changed = function(backend_name)
+  throttle_update(backend_name)
+end
+
+M._on_insert_leave = function(backend_name)
+  throttle_update(backend_name)
+end
+
+return M

--- a/lua/aerial/config.lua
+++ b/lua/aerial/config.lua
@@ -3,7 +3,7 @@ local has_devicons = pcall(require, "nvim-web-devicons")
 
 local default_options = {
   -- Priority list of preferred backends for aerial
-  backends = { "lsp", "treesitter" },
+  backends = { "lsp", "treesitter", "markdown" },
 
   -- Enum: persist, close, auto, global
   --   persist - aerial window will stay open until closed
@@ -89,6 +89,11 @@ local default_options = {
   },
 
   treesitter = {
+    -- How long to wait (in ms) after a buffer change before updating
+    update_delay = 300,
+  },
+
+  markdown = {
     -- How long to wait (in ms) after a buffer change before updating
     update_delay = 300,
   },

--- a/tests/markdown_spec.lua
+++ b/tests/markdown_spec.lua
@@ -1,27 +1,27 @@
 local util = require("tests.test_util")
 
-describe("treesitter js", function()
+describe("markdown", function()
   it("parses all symbols correctly", function()
-    util.test_file_symbols("treesitter", "./tests/treesitter/js_test.js", {
+    util.test_file_symbols("markdown", "./tests/markdown_test.md", {
       {
-        kind = "Class",
-        name = "Cl_1",
+        kind = "Interface",
+        name = "Title 1",
         level = 0,
         lnum = 1,
         col = 0,
         children = {
           {
-            kind = "Method",
-            name = "meth_1",
+            kind = "Interface",
+            name = "Title 2",
             level = 1,
-            lnum = 2,
-            col = 2,
+            lnum = 3,
+            col = 0,
           },
         },
       },
       {
-        kind = "Function",
-        name = "fn_1",
+        kind = "Interface",
+        name = "Title 3",
         level = 0,
         lnum = 5,
         col = 0,

--- a/tests/markdown_test.md
+++ b/tests/markdown_test.md
@@ -1,0 +1,5 @@
+# Title 1
+
+## Title 2
+
+# Title 3

--- a/tests/test_util.lua
+++ b/tests/test_util.lua
@@ -1,10 +1,12 @@
 local data = require("aerial.data")
-local ts = require("aerial.backends.treesitter")
+local backends = require("aerial.backends")
 local M = {}
 
-M.test_file_symbols = function(filename, expected)
+M.test_file_symbols = function(backend_name, filename, expected)
+  vim.g.aerial_backends = { backend_name }
   vim.cmd(string.format("edit %s", filename))
-  ts.fetch_symbols()
+  local backend = backends.get(0)
+  backend.fetch_symbols_sync()
   M.assert_tree_equals(data[0].items, expected)
 end
 

--- a/tests/treesitter/c_spec.lua
+++ b/tests/treesitter/c_spec.lua
@@ -2,7 +2,7 @@ local util = require("tests.test_util")
 
 describe("treesitter c", function()
   it("parses all symbols correctly", function()
-    util.test_file_symbols("./tests/treesitter/c_test.c", {
+    util.test_file_symbols("treesitter", "./tests/treesitter/c_test.c", {
       {
         kind = "Function",
         name = "fn_1",

--- a/tests/treesitter/cpp_spec.lua
+++ b/tests/treesitter/cpp_spec.lua
@@ -2,7 +2,7 @@ local util = require("tests.test_util")
 
 describe("treesitter cpp", function()
   it("parses all symbols correctly", function()
-    util.test_file_symbols("./tests/treesitter/cpp_test.cpp", {
+    util.test_file_symbols("treesitter", "./tests/treesitter/cpp_test.cpp", {
       {
         kind = "Function",
         name = "fn_1",

--- a/tests/treesitter/csharp_spec.lua
+++ b/tests/treesitter/csharp_spec.lua
@@ -2,7 +2,7 @@ local util = require("tests.test_util")
 
 describe("treesitter csharp", function()
   it("parses all symbols correctly", function()
-    util.test_file_symbols("./tests/treesitter/csharp_test.cs", {
+    util.test_file_symbols("treesitter", "./tests/treesitter/csharp_test.cs", {
       {
         kind = "Class",
         name = "Cl_1",

--- a/tests/treesitter/go_spec.lua
+++ b/tests/treesitter/go_spec.lua
@@ -2,7 +2,7 @@ local util = require("tests.test_util")
 
 describe("treesitter go", function()
   it("parses all symbols correctly", function()
-    util.test_file_symbols("./tests/treesitter/go_test.go", {
+    util.test_file_symbols("treesitter", "./tests/treesitter/go_test.go", {
       {
         kind = "Function",
         name = "fn_1",

--- a/tests/treesitter/java_spec.lua
+++ b/tests/treesitter/java_spec.lua
@@ -2,7 +2,7 @@ local util = require("tests.test_util")
 
 describe("treesitter java", function()
   it("parses all symbols correctly", function()
-    util.test_file_symbols("./tests/treesitter/java_test.java", {
+    util.test_file_symbols("treesitter", "./tests/treesitter/java_test.java", {
       {
         kind = "Interface",
         name = "Iface_1",

--- a/tests/treesitter/json_spec.lua
+++ b/tests/treesitter/json_spec.lua
@@ -2,7 +2,7 @@ local util = require("tests.test_util")
 
 describe("treesitter json", function()
   it("parses all symbols correctly", function()
-    util.test_file_symbols("./tests/treesitter/json_test.json", {
+    util.test_file_symbols("treesitter", "./tests/treesitter/json_test.json", {
       {
         kind = "Class",
         name = "obj1",

--- a/tests/treesitter/lua_spec.lua
+++ b/tests/treesitter/lua_spec.lua
@@ -2,7 +2,7 @@ local util = require("tests.test_util")
 
 describe("treesitter lua", function()
   it("parses all symbols correctly", function()
-    util.test_file_symbols("./tests/treesitter/lua_test.lua", {
+    util.test_file_symbols("treesitter", "./tests/treesitter/lua_test.lua", {
       {
         kind = "Function",
         name = "fn_1",

--- a/tests/treesitter/python_spec.lua
+++ b/tests/treesitter/python_spec.lua
@@ -2,7 +2,7 @@ local util = require("tests.test_util")
 
 describe("treesitter python", function()
   it("parses all symbols correctly", function()
-    util.test_file_symbols("./tests/treesitter/python_test.py", {
+    util.test_file_symbols("treesitter", "./tests/treesitter/python_test.py", {
       {
         kind = "Function",
         name = "fn_1",

--- a/tests/treesitter/rst_spec.lua
+++ b/tests/treesitter/rst_spec.lua
@@ -2,7 +2,7 @@ local util = require("tests.test_util")
 
 describe("treesitter rst", function()
   it("parses all symbols correctly", function()
-    util.test_file_symbols("./tests/treesitter/rst_test.rst", {
+    util.test_file_symbols("treesitter", "./tests/treesitter/rst_test.rst", {
       {
         kind = "Interface",
         name = "Title 1",

--- a/tests/treesitter/rust_spec.lua
+++ b/tests/treesitter/rust_spec.lua
@@ -2,7 +2,7 @@ local util = require("tests.test_util")
 
 describe("treesitter rust", function()
   it("parses all symbols correctly", function()
-    util.test_file_symbols("./tests/treesitter/rust_test.rs", {
+    util.test_file_symbols("treesitter", "./tests/treesitter/rust_test.rs", {
       {
         kind = "Module",
         name = "mod_1",

--- a/tests/treesitter/ts_spec.lua
+++ b/tests/treesitter/ts_spec.lua
@@ -2,7 +2,7 @@ local util = require("tests.test_util")
 
 describe("treesitter ts", function()
   it("parses all symbols correctly", function()
-    util.test_file_symbols("./tests/treesitter/ts_test.ts", {
+    util.test_file_symbols("treesitter", "./tests/treesitter/ts_test.ts", {
       {
         kind = "Function",
         name = "fn_1",

--- a/tests/treesitter/vim_spec.lua
+++ b/tests/treesitter/vim_spec.lua
@@ -2,7 +2,7 @@ local util = require("tests.test_util")
 
 describe("treesitter vim", function()
   it("parses all symbols correctly", function()
-    util.test_file_symbols("./tests/treesitter/vim_test.vim", {
+    util.test_file_symbols("treesitter", "./tests/treesitter/vim_test.vim", {
       {
         kind = "Function",
         name = "Fn_1",


### PR DESCRIPTION
Since we don't currently have a markdown parser for treesitter, this is a simple backend that should suffice for pulling out the headers.