### PR TITLE
feat: added option to automatically close aerial on select (close_on_select)

### DIFF
--- a/lua/aerial/config.lua
+++ b/lua/aerial/config.lua
@@ -79,6 +79,9 @@ local default_options = {
   -- Run this command after jumping to a symbol (false will disable)
   post_jump_cmd = "normal! zz",
 
+  -- If close_on_select is true, aerial will automatically close after jumping to a symbol
+  close_on_select = false,
+
   lsp = {
     -- Fetch document symbols when LSP diagnostics change.
     -- If you set this to false, you will need to manually fetch symbols

--- a/lua/aerial/navigation.lua
+++ b/lua/aerial/navigation.lua
@@ -215,6 +215,9 @@ M.select = function(opts)
   if config.highlight_on_jump then
     util.flash_highlight(bufnr, item.lnum, config.highlight_on_jump)
   end
+  if config.close_on_select then
+    window.close()
+  end
 end
 
 return M


### PR DESCRIPTION
This PR adds the ability to configure aerial to automatically close the window upon selecting/jumping to a symbol. Please note that vimdocs will need to be generated for this :))