### PR TITLE
Fix deprecated vim.lsp.diagnostic.get_count

### DIFF
--- a/lua/aerial/backends/lsp/callbacks.lua
+++ b/lua/aerial/backends/lsp/callbacks.lua
@@ -79,7 +79,7 @@ M.symbol_callback = function(_err, result, context, _config)
   end
   local bufnr = context.bufnr
   -- Don't update if there are diagnostics errors (or override by setting)
-  local error_count = vim.lsp.diagnostic.get_count(bufnr, "Error")
+  local error_count = #vim.diagnostic.get(bufnr, { severity = "Error" })
   local has_symbols = data:has_symbols(bufnr)
   if not config.lsp.update_when_errors and error_count > 0 and has_symbols then
     return

--- a/lua/aerial/backends/lsp/init.lua
+++ b/lua/aerial/backends/lsp/init.lua
@@ -128,7 +128,7 @@ M._on_diagnostics_changed = function()
   if not backends.is_backend_attached(0, "lsp") then
     return
   end
-  local errors = vim.lsp.diagnostic.get_count(0, "Error")
+  local errors = #vim.diagnostic.get(0, { severity = "Error" })
   -- if no errors, refresh symbols
   if config.lsp.update_when_errors or errors == 0 or not data:has_symbols() then
     M.fetch_symbols()


### PR DESCRIPTION
As of version 0.7+ the vim.lsp.diagnostic API is deprecated.

This pull request fixes the deprecated api usage