### PR TITLE
Implement padchar configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,11 @@ require("aerial").setup({
   -- This can be a function (see :help aerial-open-automatic)
   open_automatic = false,
 
+  -- The character that fills the empty space between the end of the
+  -- symbol name and the edge of the aerial window
+  -- (leaving this as "" will cause partial highlighting on current symbol)
+  padchar = " ",
+
   -- Set to true to only open aerial at the far right/left of the editor
   -- Default behavior opens aerial relative to current window
   placement_editor_edge = false,

--- a/lua/aerial/bindings.lua
+++ b/lua/aerial/bindings.lua
@@ -1,4 +1,5 @@
 local util = require("aerial.util")
+local config = require("aerial.config")
 local M = {}
 
 M.keys = {
@@ -81,7 +82,7 @@ M.show = function()
   for i = 1, #lhs do
     local left = lhs[i]
     local right = rhs[i]
-    local line = string.format(" %s   %s", util.rpad(left, max_left), right)
+    local line = string.format(" %s   %s", util.rpad(left, max_left, config.padchar), right)
     max_line = math.max(max_line, vim.api.nvim_strwidth(line))
     table.insert(lines, line)
   end

--- a/lua/aerial/config.lua
+++ b/lua/aerial/config.lua
@@ -94,6 +94,11 @@ local default_options = {
   -- This can be a function (see :help aerial-open-automatic)
   open_automatic = false,
 
+  -- The character that fills the empty space between the end of the
+  -- symbol name and the edge of the aerial window
+  -- (leaving this as "" will cause partial highlighting on current symbol)
+  padchar = " ",
+
   -- Set to true to only open aerial at the far right/left of the editor
   -- Default behavior opens aerial relative to current window
   placement_editor_edge = false,

--- a/lua/aerial/render.lua
+++ b/lua/aerial/render.lua
@@ -83,7 +83,7 @@ M.update_aerial_buffer = function(buf)
 
   -- Insert lines into buffer
   for i, line in ipairs(lines) do
-    lines[i] = util.rpad(line, width)
+    lines[i] = util.rpad(line, width, config.padchar)
   end
   vim.api.nvim_buf_set_option(aer_bufnr, "modifiable", true)
   vim.api.nvim_buf_set_lines(aer_bufnr, 0, -1, false, lines)


### PR DESCRIPTION
The the [`rpad`](https://github.com/stevearc/aerial.nvim/blob/1c78147a2aea5b00d8291b94158591dfa435ebaf/lua/aerial/util.lua#L5-L11) and [`lpad`](https://github.com/stevearc/aerial.nvim/blob/1c78147a2aea5b00d8291b94158591dfa435ebaf/lua/aerial/util.lua#L13-L18) functions have a third parameter for an (optional) padchar but in it isn't passed anywhere (omitted [here](https://github.com/stevearc/aerial.nvim/blob/de0170fce2242e3482bee8cb31858477cc456a4d/lua/aerial/bindings.lua#L84) and [here](https://github.com/stevearc/aerial.nvim/blob/1c78147a2aea5b00d8291b94158591dfa435ebaf/lua/aerial/render.lua#L86)). That leads to `" "` (whitespace) always being the padchar which (combined with a `listchar` for trailing spaces) also leads to situations like this:
![image](https://user-images.githubusercontent.com/37866329/149502576-c489f36a-5223-42a2-9110-ecb8e954f2f4.png)

In this PR, I've added a `padchar` option to the config for aerial that eliminates this problem.