### PR TITLE
Add 'ignore' configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,44 @@ require("aerial").setup({
   -- If you have lspkind-nvim installed, aerial will use it for icons.
   icons = {},
 
+  -- Control which windows and buffers aerial should ignore.
+  -- If close_behavior is "global", focusing an ignored window/buffer will
+  -- not cause the aerial window to update.
+  -- If open_automatic is true, focusing an ignored window/buffer will not
+  -- cause an aerial window to open.
+  -- If open_automatic is a function, ignore rules have no effect on aerial
+  -- window opening behavior; it's entirely handled by the open_automatic
+  -- function.
+  ignore = {
+    -- Ignore unlisted buffers. See :help buflisted
+    unlisted_buffers = true,
+
+    -- List of filetypes to ignore.
+    filetypes = {},
+
+    -- Ignored buftypes.
+    -- Can be one of the following:
+    -- false or nil - No buftypes are ignored.
+    -- "special"    - All buffers other than normal buffers are ignored.
+    -- table        - A list of buftypes to ignore. See :help buftype for the
+    --                possible values.
+    -- function     - A function that returns true if the buffer should be
+    --                ignored or false if it should not be ignored.
+    --                Takes two arguments, `bufnr` and `buftype`.
+    buftypes = "special",
+
+    -- Ignored wintypes.
+    -- Can be one of the following:
+    -- false or nil - No wintypes are ignored.
+    -- "special"    - All windows other than normal windows are ignored.
+    -- table        - A list of wintypes to ignore. See :help win_gettype() for the
+    --                possible values.
+    -- function     - A function that returns true if the window should be
+    --                ignored or false if it should not be ignored.
+    --                Takes two arguments, `winid` and `wintype`.
+    wintypes = "special",
+  },
+
   -- When you fold code with za, zo, or zc, update the aerial tree as well.
   -- Only works when manage_folds = true
   link_folds_to_tree = false,

--- a/doc/aerial.txt
+++ b/doc/aerial.txt
@@ -153,6 +153,44 @@ Configure aerial by calling the setup() function.
       -- If you have lspkind-nvim installed, aerial will use it for icons.
       icons = {},
     
+      -- Control which windows and buffers aerial should ignore.
+      -- If close_behavior is "global", focusing an ignored window/buffer will
+      -- not cause the aerial window to update.
+      -- If open_automatic is true, focusing an ignored window/buffer will not
+      -- cause an aerial window to open.
+      -- If open_automatic is a function, ignore rules have no effect on aerial
+      -- window opening behavior; it's entirely handled by the open_automatic
+      -- function.
+      ignore = {
+        -- Ignore unlisted buffers. See :help buflisted
+        unlisted_buffers = true,
+    
+        -- List of filetypes to ignore.
+        filetypes = {},
+    
+        -- Ignored buftypes.
+        -- Can be one of the following:
+        -- false or nil - No buftypes are ignored.
+        -- "special"    - All buffers other than normal buffers are ignored.
+        -- table        - A list of buftypes to ignore. See :help buftype for the
+        --                possible values.
+        -- function     - A function that returns true if the buffer should be
+        --                ignored or false if it should not be ignored.
+        --                Takes two arguments, `bufnr` and `buftype`.
+        buftypes = "special",
+    
+        -- Ignored wintypes.
+        -- Can be one of the following:
+        -- false or nil - No wintypes are ignored.
+        -- "special"    - All windows other than normal windows are ignored.
+        -- table        - A list of wintypes to ignore. See :help win_gettype() for the
+        --                possible values.
+        -- function     - A function that returns true if the window should be
+        --                ignored or false if it should not be ignored.
+        --                Takes two arguments, `winid` and `wintype`.
+        wintypes = "special",
+      },
+    
       -- When you fold code with za, zo, or zc, update the aerial tree as well.
       -- Only works when manage_folds = true
       link_folds_to_tree = false,

--- a/lua/aerial/autocommands.lua
+++ b/lua/aerial/autocommands.lua
@@ -26,7 +26,7 @@ end
 
 M.on_enter_buffer = util.throttle(function()
   backends.attach()
-  if util.is_floating_win() then
+  if util.is_ignored_win() then
     return
   end
 

--- a/lua/aerial/config.lua
+++ b/lua/aerial/config.lua
@@ -66,6 +66,44 @@ local default_options = {
   -- If you have lspkind-nvim installed, aerial will use it for icons.
   icons = {},
 
+  -- Control which windows and buffers aerial should ignore.
+  -- If close_behavior is "global", focusing an ignored window/buffer will
+  -- not cause the aerial window to update.
+  -- If open_automatic is true, focusing an ignored window/buffer will not
+  -- cause an aerial window to open.
+  -- If open_automatic is a function, ignore rules have no effect on aerial
+  -- window opening behavior; it's entirely handled by the open_automatic
+  -- function.
+  ignore = {
+    -- Ignore unlisted buffers. See :help buflisted
+    unlisted_buffers = true,
+
+    -- List of filetypes to ignore.
+    filetypes = {},
+
+    -- Ignored buftypes.
+    -- Can be one of the following:
+    -- false or nil - No buftypes are ignored.
+    -- "special"    - All buffers other than normal buffers are ignored.
+    -- table        - A list of buftypes to ignore. See :help buftype for the
+    --                possible values.
+    -- function     - A function that returns true if the buffer should be
+    --                ignored or false if it should not be ignored.
+    --                Takes two arguments, `bufnr` and `buftype`.
+    buftypes = "special",
+
+    -- Ignored wintypes.
+    -- Can be one of the following:
+    -- false or nil - No wintypes are ignored.
+    -- "special"    - All windows other than normal windows are ignored.
+    -- table        - A list of wintypes to ignore. See :help win_gettype() for the
+    --                possible values.
+    -- function     - A function that returns true if the window should be
+    --                ignored or false if it should not be ignored.
+    --                Takes two arguments, `winid` and `wintype`.
+    wintypes = "special",
+  },
+
   -- When you fold code with za, zo, or zc, update the aerial tree as well.
   -- Only works when manage_folds = true
   link_folds_to_tree = false,
@@ -291,8 +329,8 @@ M.setup = function(opts)
   end
   if type(newconf.open_automatic) == "boolean" then
     local open_automatic = newconf.open_automatic
-    newconf.open_automatic = function()
-      return open_automatic
+    newconf.open_automatic = function(bufnr)
+      return open_automatic and not require("aerial.util").is_ignored_buf(bufnr)
     end
   elseif type(newconf.open_automatic) ~= "function" then
     local open_automatic_fn = create_filetype_opt_getter(newconf.open_automatic, false)

--- a/lua/aerial/util.lua
+++ b/lua/aerial/util.lua
@@ -185,8 +185,66 @@ M.get_fixed_wins = function(bufnr)
   return wins
 end
 
+M.get_non_ignored_fixed_wins = function(bufnr)
+  return vim.tbl_map(function(winid)
+    return not M.is_ignored_win(winid)
+  end, M.get_fixed_wins(bufnr))
+end
+
 M.is_floating_win = function(winid)
   return vim.api.nvim_win_get_config(winid or 0).relative ~= ""
+end
+
+M.is_ignored_filetype = function(filetype)
+  local ignore = config.ignore
+  return ignore.filetypes and vim.tbl_contains(ignore.filetypes, filetype)
+end
+
+M.is_ignored_buf = function(bufnr)
+  local ignore = config.ignore
+  if ignore.unlisted_buffers and not vim.api.nvim_buf_get_option(bufnr, "buflisted") then
+    return true
+  end
+  if ignore.buftypes then
+    local buftype = vim.api.nvim_buf_get_option(bufnr, "buftype")
+    if ignore.buftypes == "special" and buftype ~= "" then
+      return true
+    elseif type(ignore.buftypes) == "table" then
+      if vim.tbl_contains(ignore.buftypes, buftype) then
+        return true
+      end
+    elseif type(ignore.buftypes) == "function" then
+      if ignore.buftypes(bufnr, buftype) then
+        return true
+      end
+    end
+  end
+  if ignore.filetypes then
+    local filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
+    if M.is_ignored_filetype(filetype) then
+      return true
+    end
+  end
+  return false
+end
+
+M.is_ignored_win = function(winid)
+  local bufnr = vim.api.nvim_win_get_buf(winid)
+  if M.is_ignored_buf(bufnr) then
+    return true
+  end
+  local ignore = config.ignore
+  if ignore.wintypes then
+    local wintype = vim.fn.win_gettype(winid)
+    if ignore.wintypes == "special" and wintype ~= "" then
+      return true
+    elseif type(ignore.wintypes) == "table" then
+      if vim.tbl_contains(ignore.wintypes, wintype) then
+        return true
+      end
+    end
+  end
+  return false
 end
 
 M.is_managing_folds = function(winid)

--- a/lua/aerial/window.lua
+++ b/lua/aerial/window.lua
@@ -256,7 +256,7 @@ end
 -- Updates all cursor positions for a given source buffer
 M.update_all_positions = function(bufnr, last_focused_win)
   local source_buffer = util.get_buffers(bufnr)
-  local all_source_wins = util.get_fixed_wins(source_buffer)
+  local all_source_wins = util.get_non_ignored_fixed_wins(source_buffer)
   M.update_position(all_source_wins, last_focused_win)
 end
 
@@ -280,7 +280,7 @@ M.update_position = function(winids, last_focused_win)
     return
   end
   if util.is_aerial_buffer(win_bufnr) then
-    winids = util.get_fixed_wins(bufnr)
+    winids = util.get_non_ignored_fixed_wins(bufnr)
   end
 
   local bufdata = data[bufnr]


### PR DESCRIPTION
Hi! Thank you for this wonderful plugin, it's been a great addition to my workflow.

This PR adds options to configure aerial to ignore certain windows/buffers. Ignored windows/buffers change the behavior of aerial as follows:

- If `close_behavior` is `"global"`, focusing an ignored window/buffer will not cause the aerial window to update.

- If `open_automatic` is `true`, focusing an ignored window/buffer will not cause an aerial window to open.

- If `open_automatic` is a function, ignore rules have no effect on aerial window opening behavior; it's handled by the `open_automatic` function.

The primary reason I made these changes is that when `close_behavior` is `"global"`, focusing a special window like [nvim-tree](https://github.com/kyazdani42/nvim-tree.lua) caused the aerial window to become blank. This was rather jarring; I'd prefer for the aerial buffer to stay unchanged if I focus such windows. The new `ignore.buftypes = "special"` option resolves this issue.

I added additional configuration options to give the user maximal flexibility, as there may be cases where they want to ignore a certain filetype or the buffer of a certain plugin. In most cases, though, the default options should suit the user well.

#### Notes

- Somewhat similar functionality already existed with setting `open_automatic` to a function, however, this did not help with the issue I described above with `close_behavior = "global"`.
- For the `ignore.buftypes` option, the value `"special"` is a shortcut for `ignore.buftypes = { "acwrite", "help", "nofile", "nowrite", "quickfix", "terminal", "prompt" }`. Likewise, `ignore.wintypes = "special"` is a shortcut for `ignore.wintypes = { "autocmd", "command", "loclist", "popup" "preview" "quickfix", "unknown" }`.