### PR TITLE
Add: Link to default bindings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ filtering.
 ## Default Keybindings
 
 The default keybindings in the aerial window. You can add your own in
-`ftplugin/aerial.vim`, and remove these by setting `default_bindings = false`.
+`ftplugin/aerial.vim`, and remove these by setting `default_bindings = false`. To view the default bindings and how to replace them, please see [here](https://github.com/stevearc/aerial.nvim/blob/master/lua/aerial/bindings.lua#L4).
 
 | Key       | Command                                                        |
 | --------- | -------------------------------------------------------------- |


### PR DESCRIPTION
Hi @stevearc,

Nice plugin :) I was originally trying to overwrite the key-bindings with the commands listed in the README, specifically replace `<CR>` to open the currently selected node in the AerialTree.

However there is no command I can see for this and I needed to see what the default bindings were doing. This just adds an extra link as the information of what to overwrite default bindings with seems to be missing.

Best,
Eddie