### PR TITLE
feat: highlight group for non-current split line

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,10 @@ hi link AerialGuide Comment
 " You can set a different guide color for each level
 hi AerialGuide1 guifg=Red
 hi AerialGuide2 guifg=Blue
+
+" If highlight_mode="split_width", you can set a separate color for the
+" non-current location highlight
+hi AerialLineNC guibg=Gray
 ```
 
 ## FAQ

--- a/lua/aerial/highlight.lua
+++ b/lua/aerial/highlight.lua
@@ -3,7 +3,8 @@ local M = {}
 M.create_highlight_groups = function()
   vim.cmd([[
     " The line that shows where your cursor(s) are
-    highlight default link AerialLine QuickFixLine
+    highlight default link AerialLine   QuickFixLine
+    highlight default link AerialLineNC AerialLine
 
     " The guides when show_guide = true
     highlight default link AerialGuide Comment

--- a/lua/aerial/render.lua
+++ b/lua/aerial/render.lua
@@ -204,7 +204,8 @@ M.update_highlights = function(buf)
     end
     local pos = bufdata.positions[winid]
     if config.highlight_closest or pos.exact_symbol then
-      vim.api.nvim_buf_add_highlight(aer_bufnr, ns, "AerialLine", pos.lnum - 1, start_hl, end_hl)
+      local hl_group = winid == bufdata.last_win and "AerialLine" or "AerialLineNC"
+      vim.api.nvim_buf_add_highlight(aer_bufnr, ns, hl_group, pos.lnum - 1, start_hl, end_hl)
     end
     if hl_mode ~= "full_width" then
       start_hl = end_hl


### PR DESCRIPTION
Adds a highlight group `AerialLineNC` which is applied to the portion of a split line highlight for the non-current window. Requires `highlight_mode="split_width"` to have any effect.

By default, `AerialLineNC` is linked to `AerialLine`, so users will not notice a difference from prior behavior unless they define their own `AerialLineNC` highlight group.

I chose the `NC` name because it seems to be the convention used by vim for highlights relating to non-current windows, for example [`:help hl-StatusLineNC`](https://neovim.io/doc/user/syntax.html#hl-StatusLineNC).

https://user-images.githubusercontent.com/21299126/159594894-978f6e85-fafd-4016-b5ae-0864d00e6f76.mp4