### PR TITLE
feat: add support for org files

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ automatically fetch symbols from treesitter.
 - julia
 - lua
 - markdown
+- org
 - php
 - python
 - rst

--- a/lua/aerial/backends/treesitter/language_kind_map.lua
+++ b/lua/aerial/backends/treesitter/language_kind_map.lua
@@ -64,6 +64,9 @@ return {
   markdown = {
     atx_heading = "Interface",
   },
+  org = {
+    section = "Interface",
+  },
   php = {
     anonymous_function_creation_expression = "Function",
     class_declaration = "Class",

--- a/queries/org/aerial.scm
+++ b/queries/org/aerial.scm
@@ -1,0 +1,3 @@
+(section
+  (headline
+    item: (item) @name)) @type

--- a/tests/init.lua
+++ b/tests/init.lua
@@ -6,6 +6,8 @@ vim.o.swapfile = false
 vim.bo.swapfile = false
 -- Neovim 0.5 doesn't have julia filetype detection
 vim.cmd([[autocmd BufRead,BufNewFile *.jl setfiletype julia]])
+-- Neovim below 0.7 doesn't have org filetype detection
+vim.cmd([[autocmd BufRead,BufNewFile *.org setfiletype org]])
 
 require("nvim-treesitter.configs").setup({
   ensure_installed = "all",

--- a/tests/treesitter/org_spec.lua
+++ b/tests/treesitter/org_spec.lua
@@ -1,0 +1,60 @@
+local util = require("tests.test_util")
+
+describe("org", function()
+  local symbols = {
+    {
+      kind = "Interface",
+      name = "Level1",
+      level = 0,
+      lnum = 1,
+      col = 0,
+      end_lnum = 7,
+      end_col = 0,
+      children = {
+        {
+          kind = "Interface",
+          name = "Level2",
+          level = 1,
+          lnum = 3,
+          col = 0,
+          end_lnum = 7,
+          end_col = 0,
+          children = {
+            {
+              kind = "Interface",
+              name = "Level3",
+              level = 2,
+              lnum = 5,
+              col = 0,
+              end_lnum = 7,
+              end_col = 0,
+            },
+          },
+        },
+      },
+    },
+    {
+      kind = "Interface",
+      name = "Level1_2",
+      level = 0,
+      lnum = 7,
+      col = 0,
+      end_lnum = 14,
+      end_col = 0,
+      children = {
+        {
+          kind = "Interface",
+          name = "Level2_2",
+          level = 1,
+          lnum = 11,
+          col = 0,
+          end_lnum = 14,
+          end_col = 0,
+        },
+      },
+    },
+  }
+  it("treesitter parses all symbols correctly", function()
+    util.test_file_symbols("treesitter", "./tests/treesitter/org_test.org", symbols)
+  end)
+end)

--- a/tests/treesitter/org_test.org
+++ b/tests/treesitter/org_test.org
@@ -1,0 +1,13 @@
+* Level1
+
+** Level2
+
+*** Level3
+
+* Level1_2
+
+  paragraph
+
+** Level2_2
+
+   paragraph2


### PR DESCRIPTION
Hello and thank you for the great plugin. 

I needed an overview for long `org` files hence this pull request. In principle, this acts similarly to the markdown feature, showing headlines in the specified pane:

![Screenshot_20220418_124154](https://user-images.githubusercontent.com/36173945/163778536-993f9371-59a4-4651-a79d-bb27c790ffac.png)

This uses the [tree-sitter-org](https://github.com/milisims/tree-sitter-org) parser, which isn't yet part of the nvim-treesitter repo.

I also ran the tests script and got errors for `markdown` and `org` which seems to be an issue with the `nvim-treesitter` plugin not properly recognizing custom parsers. Adding the line `vim.cmd([[runtime! plugin/orgmode.vim]])` (i.e. using the [orgmode](https://github.com/nvim-orgmode/orgmode) plugin) to the [tests/init.lua](https://github.com/stevearc/aerial.nvim/blob/3c64c5b76f2f09e23b91fd7c1dc29a6e0b953e68/tests/init.lua) file fixed the issue for `org` and its respective test passed successfully. 

So the tests work correctly, I'm just not sure if I should modify the [tests/init.lua](https://github.com/stevearc/aerial.nvim/blob/3c64c5b76f2f09e23b91fd7c1dc29a6e0b953e68/tests/init.lua) file since once `tree-sitter-org` becomes part of `nvim-treesitter`, said file will work as is, but not presently.
 
