### PR TITLE
fix: use server_capabilities instead of resolved_capabilities

### DIFF
--- a/lua/aerial/backends/lsp/callbacks.lua
+++ b/lua/aerial/backends/lsp/callbacks.lua
@@ -129,7 +129,7 @@ M.on_publish_diagnostics = function(_err, result, ctx, _config)
     not bufnr
     or not backends.is_backend_attached(bufnr, "lsp")
     or not config.lsp.diagnostics_trigger_update
-    or not client.resolved_capabilities.document_symbol
+    or not client.server_capabilities.documentSymbol
   then
     return
   end

--- a/lua/aerial/backends/lsp/init.lua
+++ b/lua/aerial/backends/lsp/init.lua
@@ -90,7 +90,7 @@ M.is_supported = function(bufnr)
   end
   if not is_lsp_attached(bufnr) then
     for _, client in pairs(vim.lsp.buf_get_clients(bufnr)) do
-      if client.resolved_capabilities.document_symbol then
+      if client.server_capabilities.documentSymbol then
         return false, "LSP client not attached (did you call aerial.on_attach?)"
       end
     end
@@ -107,7 +107,7 @@ M.on_attach = function(client, bufnr, opts)
     bufnr = 0
   end
   opts = opts or {}
-  if client.resolved_capabilities.document_symbol then
+  if client.server_capabilities.documentSymbol then
     hook_handlers(opts.preserve_callback)
     mark_lsp_attached(bufnr)
     backends.attach(bufnr, true)


### PR DESCRIPTION
```
[LSP] Accessing client.resolved_capabilities is deprecated, update your plugins or configuration to access client.server_capabilities instead.The new key/value pairs in server_capabilities directly match those defined in the language server protocol
```

https://github.com/neovim/neovim/issues/14090#issuecomment-1113956767