### PR TITLE
feat(queries): add teal support

### DIFF
--- a/lua/aerial/backends/treesitter/language_kind_map.lua
+++ b/lua/aerial/backends/treesitter/language_kind_map.lua
@@ -101,6 +101,10 @@ return {
     struct_item = "Struct",
     trait_item = "Interface",
   },
+  teal = {
+    function_statement = "Function",
+    anon_function = "Function",
+  },
   typescript = {
     arrow_function = "Function",
     class_declaration = "Class",

--- a/queries/teal/aerial.scm
+++ b/queries/teal/aerial.scm
@@ -1,0 +1,21 @@
+(function_statement
+  name: [(identifier)] @name) @type
+
+(var_declaration
+  (var_declarators
+    (var
+      name: (identifier) @name))
+  (expressions
+    (anon_function) @type)) @start
+
+(var_assignment
+    (assignment_variables
+      (var
+        (index
+          (identifier)
+          (identifier) @name)))
+    (expressions
+      (anon_function) @type)) @start
+
+(function_statement
+    name: (function_name) @name) @type

--- a/tests/treesitter/teal_spec.lua
+++ b/tests/treesitter/teal_spec.lua
@@ -1,0 +1,71 @@
+local util = require("tests.test_util")
+
+describe("treesitter teal", function()
+  it("parses all symbols correctly", function()
+    util.test_file_symbols("treesitter", "./tests/treesitter/teal_test.tl", {
+      {
+        kind = "Function",
+        name = "fn_1",
+        level = 0,
+        lnum = 1,
+        col = 0,
+        end_lnum = 3,
+        end_col = 3,
+      },
+      {
+        kind = "Function",
+        name = "fn_2",
+        level = 0,
+        lnum = 5,
+        col = 0,
+        end_lnum = 7,
+        end_col = 3,
+      },
+      {
+        kind = "Function",
+        name = "fn_3",
+        level = 0,
+        lnum = 11,
+        col = 0,
+        end_lnum = 11,
+        end_col = 23,
+      },
+      {
+        kind = "Function",
+        name = "M.launch",
+        level = 0,
+        lnum = 13,
+        col = 0,
+        end_lnum = 15,
+        end_col = 3,
+      },
+      {
+        kind = "Function",
+        name = "M.wrap",
+        level = 0,
+        lnum = 17,
+        col = 0,
+        end_lnum = 21,
+        end_col = 3,
+      },
+      {
+        kind = "Function",
+        name = "Point.new",
+        level = 0,
+        lnum = 28,
+        col = 0,
+        end_lnum = 33,
+        end_col = 3,
+      },
+      {
+        kind = "Function",
+        name = "Point:move",
+        level = 0,
+        lnum = 35,
+        col = 0,
+        end_lnum = 38,
+        end_col = 3,
+      },
+    })
+  end)
+end)

--- a/tests/treesitter/teal_test.tl
+++ b/tests/treesitter/teal_test.tl
@@ -1,0 +1,38 @@
+local function fn_1(bar: string, baz: number)
+   return bar, baz
+end
+
+local fn_2 = function()
+    return
+end
+
+local M = {}
+
+M.fn_3 = function() end
+
+function M.launch(f: function, ...)
+    return
+end
+
+function M.wrap(f: function): function
+    return function(...)
+        M.launch(f, ...)
+    end
+end
+
+local record Point
+   x: number
+   y: number
+end
+
+function Point.new(x: number, y: number): Point
+   local self = setmetatable({} as Point, { __index = Point })
+   self.x = x or 0
+   self.y = y or 0
+   return self
+end
+
+function Point:move(dx: number, dy: number)
+   self.x = self.x + dx
+   self.y = self.y + dy
+end


### PR DESCRIPTION
Thanks for great plugin! This PR adds [teal](https://github.com/teal-language/tl) (a typed dialect of Lua) language support. It's treesitter queries are analogous to Lua's.