### PR TITLE
feat(queries): add basic yaml support

### DIFF
--- a/lua/aerial/backends/treesitter/language_kind_map.lua
+++ b/lua/aerial/backends/treesitter/language_kind_map.lua
@@ -122,4 +122,8 @@ return {
   vim = {
     function_definition = "Function",
   },
+  yaml = {
+    block_mapping = "Class",
+    block_sequence = "Enum",
+  },
 }

--- a/queries/yaml/aerial.scm
+++ b/queries/yaml/aerial.scm
@@ -1,0 +1,7 @@
+(block_mapping_pair
+    key: (flow_node) @name
+    value: (block_node (block_mapping) @type)) @start
+
+(block_mapping_pair
+    key: (flow_node) @name
+    value: (block_node (block_sequence) @type)) @start

--- a/tests/treesitter/yaml_spec.lua
+++ b/tests/treesitter/yaml_spec.lua
@@ -1,0 +1,77 @@
+local util = require("tests.test_util")
+
+describe("treesitter yaml", function()
+  it("parses all symbols correctly", function()
+    util.test_file_symbols("treesitter", "./tests/treesitter/yaml_test.yml", {
+      {
+        kind = "Class",
+        name = "services",
+        level = 0,
+        lnum = 3,
+        col = 0,
+        end_lnum = 10,
+        end_col = 24,
+        children = {
+          {
+            kind = "Class",
+            name = "proxy",
+            level = 1,
+            lnum = 4,
+            col = 2,
+            end_lnum = 7,
+            end_col = 15,
+            children = {
+              {
+                kind = "Enum",
+                name = "ports",
+                level = 2,
+                lnum = 6,
+                col = 4,
+                end_lnum = 7,
+                end_col = 15,
+              },
+            },
+          },
+          {
+            kind = "Class",
+            name = "db",
+            level = 1,
+            lnum = 9,
+            col = 2,
+            end_lnum = 10,
+            end_col = 24,
+          },
+        },
+      },
+      {
+        kind = "Class",
+        name = "volumes",
+        level = 0,
+        lnum = 12,
+        col = 0,
+        end_lnum = 14,
+        end_col = 18,
+        children = {
+          {
+            kind = "Class",
+            name = "media-volume",
+            level = 1,
+            lnum = 13,
+            col = 2,
+            end_lnum = 14,
+            end_col = 18,
+          },
+        },
+      },
+      {
+        kind = "Class",
+        name = "networks",
+        level = 0,
+        lnum = 16,
+        col = 0,
+        end_lnum = 18,
+        end_col = 0,
+      },
+    })
+  end)
+end)

--- a/tests/treesitter/yaml_test.yml
+++ b/tests/treesitter/yaml_test.yml
@@ -1,0 +1,17 @@
+version: "4.7"
+
+services:
+  proxy:
+    image: "traefik:v2.5.3"
+    ports:
+      - "80:80"
+
+  db:
+    image: "postgres:14"
+
+volumes:
+  media-volume:
+    external: true
+
+networks:
+  traefik-public: null


### PR DESCRIPTION
This PR adds basic support for YAML mappings and sequences.

In aerial window it looks nice:

![window](https://user-images.githubusercontent.com/71007493/172019983-85625150-848c-421e-a5bc-9766709506be.png)

..but in Telescope picker it is not ideal and difficult to search large files:

![tele](https://user-images.githubusercontent.com/71007493/172020090-33be03e9-5c4b-411d-b177-438eb4a9137b.png)
 
Seems it would be nice if `value` column contained full key path (e.g. `services.proxy.ports`, for example [yaml.nvim](https://github.com/cuducos/yaml.nvim) plugin does something like that), but I am not sure how to do that correctly or if it's in the scope of this plugin.