### PR TITLE
close_on_select should not close aerial on preview

### DIFF
--- a/lua/aerial/navigation.lua
+++ b/lua/aerial/navigation.lua
@@ -214,14 +214,14 @@ M.select = function(opts)
 
   if opts.jump then
     vim.api.nvim_set_current_win(winid)
+    if config.close_on_select then
+      window.close()
+    end
   else
     window.update_position(winid)
   end
   if config.highlight_on_jump then
     util.flash_highlight(bufnr, item.lnum, config.highlight_on_jump)
-  end
-  if config.close_on_select then
-    window.close()
   end
 end
 


### PR DESCRIPTION
When `close_on_select` is set to true,  
aerial gets closed even when trying to preview the symbol definition with `}`, `{`, or `p`.  

Not very useful when just browsing through code using aerial,  
as this makes it impossible to actually "preview" the symbol definition.  

I think this option would be much more useful if it only closes aerial on "jump".  
(`<CR>`, `<C-v>`, `<C-s>`)
