### PR TITLE
Add basic Scala treesitter support

### DIFF
--- a/lua/aerial/backends/treesitter/language_kind_map.lua
+++ b/lua/aerial/backends/treesitter/language_kind_map.lua
@@ -113,6 +113,13 @@ return {
     struct_item = "Struct",
     trait_item = "Interface",
   },
+  scala = {
+    trait_definition = "Interface",
+    object_definition = "Class",
+    class_definition = "Class",
+    function_declaration = "Function",
+    function_definition = "Function",
+  },
   teal = {
     function_statement = "Function",
     anon_function = "Function",

--- a/queries/scala/aerial.scm
+++ b/queries/scala/aerial.scm
@@ -1,0 +1,14 @@
+(trait_definition
+  name: (identifier) @name) @type
+
+(object_definition
+  name: (identifier) @name) @type
+
+(class_definition
+  name: (identifier) @name) @type
+
+(function_declaration
+  name: (identifier) @name) @type
+
+(function_definition
+  name: (identifier) @name) @type

--- a/tests/treesitter/scala_spec.lua
+++ b/tests/treesitter/scala_spec.lua
@@ -1,0 +1,77 @@
+local util = require("tests.test_util")
+
+describe("treesitter scala", function()
+  it("parses all symbols correctly", function()
+    util.test_file_symbols("treesitter", "./tests/treesitter/scala_test.scala", {
+      {
+        kind = "Class",
+        name = "Object",
+        level = 0,
+        lnum = 1,
+        col = 0,
+        end_lnum = 5,
+        end_col = 1,
+        children = {
+          {
+            kind = "Function",
+            name = "foo",
+            level = 1,
+            lnum = 2,
+            col = 2,
+            end_lnum = 4,
+            end_col = 3,
+          },
+        },
+      },
+      {
+        kind = "Interface",
+        name = "Trait",
+        level = 0,
+        lnum = 7,
+        col = 0,
+        end_lnum = 9,
+        end_col = 1,
+        children = {
+          {
+            kind = "Function",
+            name = "foo",
+            level = 1,
+            lnum = 8,
+            col = 2,
+            end_lnum = 8,
+            end_col = 23,
+          },
+        },
+      },
+      {
+        kind = "Class",
+        name = "Class",
+        level = 0,
+        lnum = 11,
+        col = 0,
+        end_lnum = 18,
+        end_col = 1,
+        children = {
+          {
+            kind = "Function",
+            name = "foo",
+            level = 1,
+            lnum = 12,
+            col = 2,
+            end_lnum = 14,
+            end_col = 3,
+          },
+          {
+            kind = "Function",
+            name = "bar",
+            level = 1,
+            lnum = 15,
+            col = 2,
+            end_lnum = 17,
+            end_col = 3,
+          },
+        },
+      },
+    })
+  end)
+end)

--- a/tests/treesitter/scala_test.scala
+++ b/tests/treesitter/scala_test.scala
@@ -1,0 +1,18 @@
+object Object {
+  def foo(x: Int): Int = {
+    ???
+  }
+}
+
+trait Trait {
+  def foo(x: Int): Unit
+}
+
+class Class {
+  def foo(x: Int): Unit = {
+    ???
+  }
+  def bar(x: Int): Unit = {
+    ???
+  }
+}


### PR DESCRIPTION
Adding basic support for the Scala language, solving https://github.com/stevearc/aerial.nvim/issues/139. It can potentially be extended, as this version only supports traits, objects, classes, and functions.