### PR TITLE
Refactor close_behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,26 +247,29 @@ require("aerial").setup({
     width = nil,
     min_width = 10,
 
-    -- Enum: prefer_right, prefer_left, right, left, float
     -- Determines the default direction to open the aerial window. The 'prefer'
     -- options will open the window in the other direction *if* there is a
     -- different buffer in the way of the preferred direction
+    -- Enum: prefer_right, prefer_left, right, left, float
     default_direction = "prefer_right",
 
-    -- Enum: edge, group, window
+    -- Determines where the aerial window will be opened
     --   edge   - open aerial at the far right/left of the editor
     --   group  - open aerial to the right/left of the group of windows containing the current buffer
     --   window - open aerial to the right/left of the current window
     placement = "window",
   },
 
-  -- Enum: persist, close, auto, global
-  --   persist - aerial window will stay open until closed
-  --   close   - aerial window will close when original file is no longer visible
-  --   auto    - aerial window will stay open as long as there is a visible
-  --             buffer to attach to
-  --   global  - same as 'persist', and will always show symbols for the current buffer
-  close_behavior = "auto",
+  -- Determines how the aerial window decides which buffer to display symbols for
+  --   window - aerial window will display symbols for the buffer in the window from which it was opened
+  --   global - aerial window will display symbols for the current window
+  attach_mode = "window",
+
+  -- List of enum values that configure when to auto-close the aerial window
+  --   unfocus       - close aerial when you leave the original source window
+  --   switch_buffer - close aerial when you change buffers in the source window
+  --   unsupported   - close aerial when attaching to a buffer that has no symbol source
+  close_automatic_events = {},
 
   -- Set to false to remove the default keybindings for the aerial buffer
   default_bindings = true,
@@ -291,7 +294,6 @@ require("aerial").setup({
     "Struct",
   },
 
-  -- Enum: split_width, full_width, last, none
   -- Determines line highlighting mode when multiple splits are visible.
   -- split_width   Each open window will have its cursor location marked in the
   --               aerial buffer. Each line will only be partially highlighted
@@ -322,7 +324,7 @@ require("aerial").setup({
   icons = {},
 
   -- Control which windows and buffers aerial should ignore.
-  -- If close_behavior is "global", focusing an ignored window/buffer will
+  -- If attach_mode is "global", focusing an ignored window/buffer will
   -- not cause the aerial window to update.
   -- If open_automatic is true, focusing an ignored window/buffer will not
   -- cause an aerial window to open.
@@ -416,7 +418,7 @@ require("aerial").setup({
     -- Controls border appearance. Passed to nvim_open_win
     border = "rounded",
 
-    -- Enum: cursor, editor, win
+    -- Determines location of floating window
     --   cursor - Opens float on top of the cursor
     --   editor - Opens float centered in the editor
     --   win    - Opens float centered in the window

--- a/doc/aerial.txt
+++ b/doc/aerial.txt
@@ -372,6 +372,16 @@ replicate the old behavior you could get with `open_automatic_min_lines` and
         }
 <
 
+                                                            *aerial-close-behavior*
+The `close_behavior` config option has been replaced by a combination of
+`attach_mode` and `close_automatic_events`. I would recommend reading the docs
+for each of these, but a migration cheat-sheet is provided below.
+>
+    close_behavior = "global"  -->  attach_mode = "global"
+    close_behavior = "persist" -->  this is the new effective default
+    close_behavior = "auto"    -->  close_automatic_events = { "unsupported" }
+    close_behavior = "close"   -->  close_automatic_events = { "switch_buffer" }
+<
 
                                                               *SymbolKind* *symbol*
 A quick note on SymbolKind. An authoritative list of valid SymbolKinds can be

--- a/doc/aerial.txt
+++ b/doc/aerial.txt
@@ -119,26 +119,29 @@ Configure aerial by calling the setup() function.
         width = nil,
         min_width = 10,
     
-        -- Enum: prefer_right, prefer_left, right, left, float
         -- Determines the default direction to open the aerial window. The 'prefer'
         -- options will open the window in the other direction *if* there is a
         -- different buffer in the way of the preferred direction
+        -- Enum: prefer_right, prefer_left, right, left, float
         default_direction = "prefer_right",
     
-        -- Enum: edge, group, window
+        -- Determines where the aerial window will be opened
         --   edge   - open aerial at the far right/left of the editor
         --   group  - open aerial to the right/left of the group of windows containing the current buffer
         --   window - open aerial to the right/left of the current window
         placement = "window",
       },
     
-      -- Enum: persist, close, auto, global
-      --   persist - aerial window will stay open until closed
-      --   close   - aerial window will close when original file is no longer visible
-      --   auto    - aerial window will stay open as long as there is a visible
-      --             buffer to attach to
-      --   global  - same as 'persist', and will always show symbols for the current buffer
-      close_behavior = "auto",
+      -- Determines how the aerial window decides which buffer to display symbols for
+      --   window - aerial window will display symbols for the buffer in the window from which it was opened
+      --   global - aerial window will display symbols for the current window
+      attach_mode = "window",
+    
+      -- List of enum values that configure when to auto-close the aerial window
+      --   unfocus       - close aerial when you leave the original source window
+      --   switch_buffer - close aerial when you change buffers in the source window
+      --   unsupported   - close aerial when attaching to a buffer that has no symbol source
+      close_automatic_events = {},
     
       -- Set to false to remove the default keybindings for the aerial buffer
       default_bindings = true,
@@ -163,7 +166,6 @@ Configure aerial by calling the setup() function.
         "Struct",
       },
     
-      -- Enum: split_width, full_width, last, none
       -- Determines line highlighting mode when multiple splits are visible.
       -- split_width   Each open window will have its cursor location marked in the
       --               aerial buffer. Each line will only be partially highlighted
@@ -194,7 +196,7 @@ Configure aerial by calling the setup() function.
       icons = {},
     
       -- Control which windows and buffers aerial should ignore.
-      -- If close_behavior is "global", focusing an ignored window/buffer will
+      -- If attach_mode is "global", focusing an ignored window/buffer will
       -- not cause the aerial window to update.
       -- If open_automatic is true, focusing an ignored window/buffer will not
       -- cause an aerial window to open.
@@ -288,7 +290,7 @@ Configure aerial by calling the setup() function.
         -- Controls border appearance. Passed to nvim_open_win
         border = "rounded",
     
-        -- Enum: cursor, editor, win
+        -- Determines location of floating window
         --   cursor - Opens float on top of the cursor
         --   editor - Opens float centered in the editor
         --   win    - Opens float centered in the window

--- a/doc/tags
+++ b/doc/tags
@@ -20,6 +20,7 @@
 Aerial	aerial.txt	/*Aerial*
 SymbolKind	aerial.txt	/*SymbolKind*
 aerial	aerial.txt	/*aerial*
+aerial-close-behavior	aerial.txt	/*aerial-close-behavior*
 aerial-commands	aerial.txt	/*aerial-commands*
 aerial-contents	aerial.txt	/*aerial-contents*
 aerial-filetype-map	aerial.txt	/*aerial-filetype-map*

--- a/lua/aerial/autocommands.lua
+++ b/lua/aerial/autocommands.lua
@@ -9,17 +9,63 @@ local window = require("aerial.window")
 
 local M = {}
 
-local function is_sticky(behavior)
-  return behavior == "persist" or behavior == "global"
+local maybe_open_automatic = util.throttle(function()
+  window.maybe_open_automatic()
+end, { delay = 5, reset_timer_on_call = true })
+
+---@param aer_win integer
+---@return boolean
+local function should_close_aerial(aer_win)
+  local aer_buf = vim.api.nvim_win_get_buf(aer_win)
+  local src_win = util.get_source_win(aer_win)
+  -- If the aerial window has no valid source window, close it
+  if not src_win then
+    return true
+  end
+  local src_buf = util.get_source_buffer(aer_buf)
+
+  if config.close_automatic_events.unfocus then
+    -- Close the window if the aerial source win is not the current win
+    if src_win ~= vim.api.nvim_get_current_win() then
+      return true
+    end
+  end
+
+  -- Close the aerial window if its attached buffer is unsupported
+  if config.close_automatic_events.unsupported then
+    if not vim.api.nvim_buf_is_valid(src_buf) or not backends.get(src_buf) then
+      return true
+    end
+  end
+  return false
 end
 
-local function close_orphans()
-  local orphans = util.get_aerial_orphans()
-  for _, winid in ipairs(orphans) do
-    if is_sticky(config.close_behavior) then
-      render.clear_buffer(vim.api.nvim_win_get_buf(winid))
-    else
-      vim.api.nvim_win_close(winid, true)
+local function update_aerial_windows()
+  for _, winid in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
+    local winbuf = vim.api.nvim_win_get_buf(winid)
+    if util.is_aerial_buffer(winbuf) then
+      local close = false
+      if config.attach_mode == "global" then
+        window.open_aerial_in_win(0, 0, winid)
+      elseif config.attach_mode == "window" then
+        local src_win = util.get_source_win(winid)
+        local src_buf = vim.api.nvim_win_get_buf(src_win)
+
+        -- Close the aerial window if its source window has switched buffers
+        if config.close_automatic_events.switch_buffer then
+          if src_buf ~= util.get_source_buffer(winbuf) then
+            close = true
+          end
+        end
+
+        if util.get_source_win(winid) == vim.api.nvim_get_current_win() then
+          window.open_aerial_in_win(src_buf, src_win, winid)
+        end
+      end
+
+      if close or should_close_aerial(winid) then
+        vim.api.nvim_win_close(winid, true)
+      end
     end
   end
 end
@@ -31,47 +77,33 @@ M.on_enter_buffer = util.throttle(function()
   end
 
   local mybuf = vim.api.nvim_get_current_buf()
-  if not util.is_aerial_buffer(mybuf) then
-    if config.close_behavior == "close" then
-      close_orphans()
-    end
-
-    -- If we're not in supported buffer
-    local backend = backends.get()
-    if not backend then
-      fold.restore_foldmethod()
-      close_orphans()
-      return
-    end
-
-    fold.maybe_set_foldmethod()
-  end
 
   if util.is_aerial_buffer(mybuf) then
+    local source_win = util.get_source_win()
     if
-      (not is_sticky(config.close_behavior) and util.is_aerial_buffer_orphaned(mybuf))
-      or vim.tbl_count(vim.api.nvim_list_wins()) == 1
+      (not source_win and config.attach_mode ~= "global")
+      or vim.tbl_count(vim.api.nvim_tabpage_list_wins(0)) == 1
     then
       vim.cmd("quit")
     else
       -- Hack to ignore winwidth
       util.restore_width(0)
     end
-  elseif window.is_open() then
-    close_orphans()
-    render.update_aerial_buffer()
+    return
+  end
+
+  update_aerial_windows()
+
+  -- If we're not in supported buffer
+  local backend = backends.get()
+  if not backend then
+    fold.restore_foldmethod()
   else
-    local orphans = util.get_aerial_orphans()
-    if orphans[1] then
-      -- open our symbols in that window
-      vim.defer_fn(function()
-        window.open(false, nil, { winid = orphans[1] })
-      end, 5)
-    else
-      vim.defer_fn(function()
-        window.maybe_open_automatic()
-      end, 5)
-    end
+    fold.maybe_set_foldmethod()
+  end
+
+  if not window.is_open() then
+    maybe_open_automatic()
   end
 end, { delay = 10, reset_timer_on_call = true })
 

--- a/lua/aerial/autocommands.lua
+++ b/lua/aerial/autocommands.lua
@@ -49,17 +49,19 @@ local function update_aerial_windows()
         window.open_aerial_in_win(0, 0, winid)
       elseif config.attach_mode == "window" then
         local src_win = util.get_source_win(winid)
-        local src_buf = vim.api.nvim_win_get_buf(src_win)
+        if src_win then
+          local src_buf = vim.api.nvim_win_get_buf(src_win)
 
-        -- Close the aerial window if its source window has switched buffers
-        if config.close_automatic_events.switch_buffer then
-          if src_buf ~= util.get_source_buffer(winbuf) then
-            close = true
+          -- Close the aerial window if its source window has switched buffers
+          if config.close_automatic_events.switch_buffer then
+            if src_buf ~= util.get_source_buffer(winbuf) then
+              close = true
+            end
           end
-        end
 
-        if util.get_source_win(winid) == vim.api.nvim_get_current_win() then
-          window.open_aerial_in_win(src_buf, src_win, winid)
+          if util.get_source_win(winid) == vim.api.nvim_get_current_win() then
+            window.open_aerial_in_win(src_buf, src_win, winid)
+          end
         end
       end
 

--- a/lua/aerial/config.lua
+++ b/lua/aerial/config.lua
@@ -1,6 +1,3 @@
-local HAS_DEVICONS = pcall(require, "nvim-web-devicons")
-local HAS_LSPKIND, lspkind = pcall(require, "lspkind")
-
 local default_options = {
   -- Priority list of preferred backends for aerial.
   -- This can be a filetype map (see :help aerial-filetype-map)
@@ -341,7 +338,9 @@ M.setup = function(opts)
 
   local newconf = vim.tbl_deep_extend("force", default_options, opts)
   if newconf.nerd_font == "auto" then
-    newconf.nerd_font = HAS_DEVICONS or HAS_LSPKIND
+    local has_devicons = pcall(require, "nvim-web-devicons")
+    local has_lspkind = pcall(require, "lspkind")
+    newconf.nerd_font = has_devicons or has_lspkind
   end
 
   -- Undocumented use_lspkind option for tests. End users can simply provide
@@ -466,7 +465,8 @@ M.get_icon = function(bufnr, kind, collapsed)
     end
   end
 
-  if HAS_LSPKIND and M.use_lspkind and not collapsed then
+  local has_lspkind, lspkind = pcall(require, "lspkind")
+  if has_lspkind and M.use_lspkind and not collapsed then
     icon = lspkind.symbolic(kind, { with_text = false })
     if icon and icon ~= "" then
       return icon

--- a/lua/aerial/config.lua
+++ b/lua/aerial/config.lua
@@ -393,10 +393,6 @@ M.setup = function(opts)
   newconf.highlight_mode =
     assert_enum(newconf.highlight_mode, { "split_width", "full_width", "last", "none" })
 
-  if newconf.auto_close ~= "persist" and newconf.auto_attach == "global" then
-    newconf.auto_close = "persist"
-  end
-
   if newconf.nerd_font == "auto" then
     local has_devicons = pcall(require, "nvim-web-devicons")
     local has_lspkind = pcall(require, "lspkind")

--- a/lua/aerial/config.lua
+++ b/lua/aerial/config.lua
@@ -12,26 +12,29 @@ local default_options = {
     width = nil,
     min_width = 10,
 
-    -- Enum: prefer_right, prefer_left, right, left, float
     -- Determines the default direction to open the aerial window. The 'prefer'
     -- options will open the window in the other direction *if* there is a
     -- different buffer in the way of the preferred direction
+    -- Enum: prefer_right, prefer_left, right, left, float
     default_direction = "prefer_right",
 
-    -- Enum: edge, group, window
+    -- Determines where the aerial window will be opened
     --   edge   - open aerial at the far right/left of the editor
     --   group  - open aerial to the right/left of the group of windows containing the current buffer
     --   window - open aerial to the right/left of the current window
     placement = "window",
   },
 
-  -- Enum: persist, close, auto, global
-  --   persist - aerial window will stay open until closed
-  --   close   - aerial window will close when original file is no longer visible
-  --   auto    - aerial window will stay open as long as there is a visible
-  --             buffer to attach to
-  --   global  - same as 'persist', and will always show symbols for the current buffer
-  close_behavior = "auto",
+  -- Determines how the aerial window decides which buffer to display symbols for
+  --   window - aerial window will display symbols for the buffer in the window from which it was opened
+  --   global - aerial window will display symbols for the current window
+  attach_mode = "window",
+
+  -- List of enum values that configure when to auto-close the aerial window
+  --   unfocus       - close aerial when you leave the original source window
+  --   switch_buffer - close aerial when you change buffers in the source window
+  --   unsupported   - close aerial when attaching to a buffer that has no symbol source
+  close_automatic_events = {},
 
   -- Set to false to remove the default keybindings for the aerial buffer
   default_bindings = true,
@@ -56,7 +59,6 @@ local default_options = {
     "Struct",
   },
 
-  -- Enum: split_width, full_width, last, none
   -- Determines line highlighting mode when multiple splits are visible.
   -- split_width   Each open window will have its cursor location marked in the
   --               aerial buffer. Each line will only be partially highlighted
@@ -87,7 +89,7 @@ local default_options = {
   icons = {},
 
   -- Control which windows and buffers aerial should ignore.
-  -- If close_behavior is "global", focusing an ignored window/buffer will
+  -- If attach_mode is "global", focusing an ignored window/buffer will
   -- not cause the aerial window to update.
   -- If open_automatic is true, focusing an ignored window/buffer will not
   -- cause an aerial window to open.
@@ -181,7 +183,7 @@ local default_options = {
     -- Controls border appearance. Passed to nvim_open_win
     border = "rounded",
 
-    -- Enum: cursor, editor, win
+    -- Determines location of floating window
     --   cursor - Opens float on top of the cursor
     --   editor - Opens float centered in the editor
     --   win    - Opens float centered in the window
@@ -321,6 +323,28 @@ local function compat_move_option(opts, key, nested_key)
   end
 end
 
+---@param value string
+---@param values string[]
+---@param opts? {allow_nil: boolean}
+local function assert_enum(value, values, opts)
+  opts = opts or {}
+  local valid
+  if value == nil then
+    valid = opts.allow_nil
+  else
+    valid = vim.tbl_contains(values, value)
+  end
+  if valid then
+    return value
+  else
+    vim.notify(
+      string.format("Aerial got '%s', expected one of %s", value, table.concat(values, ", ")),
+      vim.log.levels.WARN
+    )
+    return values[1]
+  end
+end
+
 M.setup = function(opts)
   opts = opts or {}
 
@@ -336,11 +360,52 @@ M.setup = function(opts)
   end
   compat_move_option(opts, "placement_editor_edge", "layout")
 
+  if opts.close_behavior then
+    if opts.close_behavior == "global" then
+      opts.attach_mode = "global"
+    elseif opts.close_behavior == "persist" then
+      -- pass
+    elseif opts.close_behavior == "close" then
+      opts.close_automatic_events = { "switch_buffer" }
+    elseif opts.close_behavior == "auto" then
+      opts.close_automatic_events = { "unsupported" }
+    end
+    opts.close_behavior = nil
+    vim.notify(
+      "Deprecated[aerial]: close_behavior is deprecated. See :help aerial-close-behavior",
+      vim.log.levels.WARN
+    )
+  end
+
   local newconf = vim.tbl_deep_extend("force", default_options, opts)
+
+  -- Asserts for all enum values
+  newconf.layout.default_direction = assert_enum(
+    newconf.layout.default_direction,
+    { "prefer_right", "prefer_left", "right", "left", "float" }
+  )
+  newconf.layout.placement = assert_enum(newconf.layout.placement, { "window", "edge", "group" })
+  newconf.attach_mode = assert_enum(newconf.attach_mode, { "window", "global" })
+  for i, v in ipairs(newconf.close_automatic_events) do
+    newconf.close_automatic_events[i] =
+      assert_enum(v, { "unfocus", "switch_buffer", "unsupported" })
+  end
+  newconf.highlight_mode =
+    assert_enum(newconf.highlight_mode, { "split_width", "full_width", "last", "none" })
+
+  if newconf.auto_close ~= "persist" and newconf.auto_attach == "global" then
+    newconf.auto_close = "persist"
+  end
+
   if newconf.nerd_font == "auto" then
     local has_devicons = pcall(require, "nvim-web-devicons")
     local has_lspkind = pcall(require, "lspkind")
     newconf.nerd_font = has_devicons or has_lspkind
+  end
+
+  -- Add lookup to close_automatic_events
+  for i, v in ipairs(newconf.close_automatic_events) do
+    newconf.close_automatic_events[v] = i
   end
 
   -- Undocumented use_lspkind option for tests. End users can simply provide

--- a/lua/aerial/init.lua
+++ b/lua/aerial/init.lua
@@ -20,7 +20,7 @@ M.setup = function(opts)
   vim.cmd([[
     aug AerialEnterBuffer
       au!
-      au BufEnter * lua require'aerial.autocommands'.on_enter_buffer()
+      au WinEnter,BufEnter * lua require'aerial.autocommands'.on_enter_buffer()
     aug END
   ]])
   command.create_commands()
@@ -285,22 +285,13 @@ end
 
 ---Print out debug information for aerial
 M.info = function()
-  local filetype = vim.api.nvim_buf_get_option(0, "filetype")
+  local bufnr = util.get_buffers(0)
+  local filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
   print("Aerial Info")
   print("-----------")
   print(string.format("Filetype: %s", filetype))
   print("Configured backends:")
-  for _, name in ipairs(config.backends(0)) do
-    local line = "  " .. name
-    local supported, err = backends.is_supported(0, name)
-    if supported then
-      line = line .. " (supported)"
-    else
-      line = line .. " (not supported) [" .. err .. "]"
-    end
-    if backends.is_backend_attached(0, name) then
-      line = line .. " (attached)"
-    end
+  for _, line in ipairs(backends.get_status_lines(bufnr)) do
     print(line)
   end
   print(string.format("Show symbols: %s", config.get_filter_kind_map()))

--- a/lua/aerial/render.lua
+++ b/lua/aerial/render.lua
@@ -1,3 +1,4 @@
+local backends = require("aerial.backends")
 local config = require("aerial.config")
 local data = require("aerial.data")
 local layout = require("aerial.layout")
@@ -74,8 +75,13 @@ M.update_aerial_buffer = function(buf)
   end
   if not data:has_symbols(bufnr) then
     local lines = { "No symbols" }
-    if config.lsp.filter_kind ~= false then
-      table.insert(lines, ":help aerial-filter")
+    if backends.get(bufnr) then
+      if config.lsp.filter_kind ~= false then
+        table.insert(lines, ":help aerial-filter")
+      end
+    else
+      table.insert(lines, "")
+      vim.list_extend(lines, backends.get_status_lines(bufnr))
     end
     resize_all_wins(aer_bufnr)
     util.render_centered_text(aer_bufnr, lines)

--- a/lua/aerial/window.lua
+++ b/lua/aerial/window.lua
@@ -3,6 +3,7 @@ local bindings = require("aerial.bindings")
 local config = require("aerial.config")
 local data = require("aerial.data")
 local layout = require("aerial.layout")
+local loading = require("aerial.loading")
 local render = require("aerial.render")
 local util = require("aerial.util")
 
@@ -49,6 +50,9 @@ local function create_aerial_buffer(bufnr)
     aer_bufnr,
     aer_bufnr
   ))
+  if not data:has_symbols(bufnr) then
+    loading.set_loading(aer_bufnr, true)
+  end
   return aer_bufnr
 end
 

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -12,7 +12,7 @@ describe("config", function()
 
   it("falls back to default options", function()
     config.setup()
-    assert.equals(config.close_behavior, "auto")
+    assert.equals(config.attach_mode, "window")
   end)
 
   -- Filetype maps


### PR DESCRIPTION
closes #128

Splits `close_behavior` into two new options: `attach_mode` and `close_automatic_events`. Also includes a complete rewrite of the logic that handles updating/autoclosing aerial windows, so it's quite possible some bugs slipped through.