### PR TITLE
fix open_automatic not working

### DIFF
--- a/lua/aerial/init.lua
+++ b/lua/aerial/init.lua
@@ -306,7 +306,7 @@ M.setup = function(opts)
     create_autocmds()
   end
 
-  if initialized then
+  if not initialized then
     do_setup()
   end
 end


### PR DESCRIPTION
I set `open_automatic = true` but aerial window not shows when I open a supported buffer. 

`lua=require'aerial.window'.maybe_open_automatic()` shows `E5108: Error executing lua ...vim/site/pack/lazy/opt/aerial.nvim/lua/aerial/window.lua:279: attempt to call field 'open_automatic' (a nil value)`, and `lua=require'aerial.config'.open_automatic` is `nil`.

So maybe it's not initialized?