### PR TITLE
fix: escape % in lualine component

### DIFF
--- a/lua/lualine/components/aerial.lua
+++ b/lua/lualine/components/aerial.lua
@@ -80,7 +80,7 @@ function M:format_status(symbols, depth, separator, icons_enabled, colored)
   end
 
   for _, symbol in ipairs(symbols) do
-    local name = symbol.name
+    local name = utils.stl_escape(symbol.name)
     if colored then
       name = self:format_hl(self.highlight_groups[symbol.kind].text) .. name
     end


### PR DESCRIPTION
<img width="522" alt="image" src="https://user-images.githubusercontent.com/61075605/211071906-8f739f0f-6883-4a86-a0a0-5e0fbe3f27de.png">
The following code makes lualine component crash because the symbol name contains '%'.

After this commit it should work.
<img width="596" alt="image" src="https://user-images.githubusercontent.com/61075605/211072152-c434e3c4-88b4-4f4f-b7be-fa58f7101a8d.png">
