### PR TITLE
extra options for the telescope integration

### DIFF
--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -36,14 +36,15 @@ local function aerial_picker(opts)
     backend.fetch_symbols_sync(0, opts)
   end
 
-  local displayer = entry_display.create({
-    separator = " ",
-    items = {
-      { width = 4 },
-      { width = 30 },
-      { remaining = true },
-    },
-  })
+  local displayer = opts.displayer
+    or entry_display.create({
+      separator = " ",
+      items = {
+        { width = 4 },
+        { width = 30 },
+        { remaining = true },
+      },
+    })
 
   local function make_display(entry)
     local item = entry.value
@@ -60,11 +61,15 @@ local function aerial_picker(opts)
 
   local function make_entry(item)
     local name = item.name
-    if show_nesting then
-      local cur = item.parent
-      while cur do
-        name = string.format("%s.%s", cur.name, name)
-        cur = cur.parent
+    if opts.get_entry_text ~= nil then
+      name = opts.get_entry_text(item)
+    else
+      if show_nesting then
+        local cur = item.parent
+        while cur do
+          name = string.format("%s.%s", cur.name, name)
+          cur = cur.parent
+        end
       end
     end
     return {


### PR DESCRIPTION
Hi! Great plugin!

I'd be interested in some extra customization for the telescope integration... In general telescope allows most things to be customizable through the opts parameter.

I've tried to make the entire make_entry customizable, but then it pulled half of the integration in my config file, because it pulls in make_display, displayer and so on.

So for now I came up with this simple approach, which is maybe not powerful enough (with this granular way, there may be a need for further integration points).

A way to make it more extensible without multiple extension points would be to use less local functions, but I understand you do that to achieve lazy loading, so I don't have any better idea..

As for the local modifications I'd like to achieve with these extension points: width 2 instead of 4 for the first column in the displayer.. and for the entry text have nesting.. but only a single level (not recursive), and only if the parent name is shorter than 20 characters.