### PR TITLE
fix Lualine customize example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ require("lualine").setup({
     lualine_x = { "aerial" },
 
     -- Or you can customize it
-    lualine_y = { "aerial",
+    lualine_y = {{ "aerial",
       -- The separator to be used to separate symbols in status line.
       sep = ' ) ',
 
@@ -530,7 +530,7 @@ require("lualine").setup({
 
       -- Color the symbol icons.
       colored = true,
-    },
+    }},
   },
 })
 ```


### PR DESCRIPTION
Appreciate for your convenient plugin!
When testing your example code to customize lualine, I found that the original code of ``lualine_y`` leaded to a warning after restarting neovim. It says: 
```
lualine: There are some issues with your config. Run :LualineNotices for details
```
According to the hints in ``LualineNotices``, it turns out that another pair of curly braces is required. So I add these two braces for new comers like me in this PR.