### PR TITLE
typescript: don't display in-function items

### DIFF
--- a/lua/aerial/backends/treesitter/extensions.lua
+++ b/lua/aerial/backends/treesitter/extensions.lua
@@ -290,6 +290,15 @@ M.typescript = {
       local str = vim.treesitter.query.get_node_text(string, bufnr) or "<parse error>"
       item.name = fn .. " " .. str
     end
+
+    -- we don't want to display in-function items
+    local cur_parent = value_node and value_node:parent()
+    while cur_parent do
+      if cur_parent:type() == "arrow_function" or cur_parent:type() == "function_declaration" then
+        return false
+      end
+      cur_parent = cur_parent:parent()
+    end
   end,
 }
 

--- a/tests/treesitter/ts_spec.lua
+++ b/tests/treesitter/ts_spec.lua
@@ -92,7 +92,7 @@ describe("treesitter ts", function()
         level = 0,
         lnum = 18,
         col = 0,
-        end_lnum = 30,
+        end_lnum = 32,
         end_col = 2,
         children = {
           {
@@ -188,6 +188,15 @@ describe("treesitter ts", function()
             },
           },
         },
+      },
+      {
+        kind = "Function",
+        name = "fn_4",
+        level = 0,
+        lnum = 34,
+        col = 0,
+        end_lnum = 37,
+        end_col = 1,
       },
     })
   end)

--- a/tests/treesitter/ts_test.ts
+++ b/tests/treesitter/ts_test.ts
@@ -27,4 +27,11 @@ describe("UnitTest", () => {
   describe.each([])("Test Suite", () => {
     test.each([])("runs multiple times", () => {});
   });
+  const local_const_var = "value";
+  let local_let_var = "value";
 });
+
+function fn_4() {
+  const local_const_var = "value";
+  let local_let_var = "value";
+}


### PR DESCRIPTION
fixes #214

This PR makes it that we don't take into account variables that are nested under functions for typescript. This fixes my bug #214 -- the items are not necessarily marked as functions, but it's ok as long as they're displayed. However I don't want to fill in my display with local variables, and I guess most people also don't.

So it seems to me this fixes my personal issue and should be useful for everyone.