### PR TITLE
ability to display private symbols differently

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,8 +591,9 @@ require("lualine").setup({
 ## Highlight
 
 There are highlight groups created for each `SymbolKind`. There will be one for
-the name of the symbol (`Aerial<SymbolKind>`, and one for the icon
-(`Aerial<SymbolKind>Icon`). For example:
+the name of the symbol (`Aerial<SymbolKind>`), one for name and scope (`Aerial<SymbolKind>Private`),
+one for the icon (`Aerial<SymbolKind>Icon`), and one for the icon with scope (`Aerial<SymbolKind>PrivateIcon`).
+For example:
 
 ```vim
 hi link AerialClass Type

--- a/lua/aerial/backends/treesitter/extensions.lua
+++ b/lua/aerial/backends/treesitter/extensions.lua
@@ -72,6 +72,9 @@ M.elixir = {
     local identifier = (utils.get_at_path(match, "identifier") or {}).node
     if identifier then
       local name = vim.treesitter.query.get_node_text(identifier, bufnr) or "<parse error>"
+      if name == "defp" then
+        item.scope = "Private"
+      end
       item.kind = M.elixir.kind_map[name] or item.kind
       if name == "callback" and item.parent then
         item.parent.kind = "Interface"

--- a/lua/aerial/highlight.lua
+++ b/lua/aerial/highlight.lua
@@ -29,6 +29,7 @@ M.create_highlight_groups = function()
   -- The name of the symbol
   for _, symbol_kind in ipairs(M.identifiers) do
     link(string.format("Aerial%s", symbol_kind), "NONE")
+    vim.cmd(string.format("hi Aerial%sPrivate cterm=italic gui=italic", symbol_kind))
   end
 
   -- The icon displayed to the left of the symbol
@@ -43,6 +44,7 @@ M.create_highlight_groups = function()
   link("AerialFieldIcon", "Identifier")
   link("AerialFileIcon", "Identifier")
   link("AerialFunctionIcon", "Function")
+  link("AerialFunctionPrivateIcon", "NONE")
   link("AerialInterfaceIcon", "Type")
   link("AerialKeyIcon", "Identifier")
   link("AerialMethodIcon", "Function")

--- a/lua/aerial/render.lua
+++ b/lua/aerial/render.lua
@@ -151,13 +151,13 @@ M.update_aerial_buffer = function(buf)
     local text = util.remove_newlines(string.format("%s%s %s", spacing, kind, item.name))
     local text_cols = vim.api.nvim_strwidth(text)
     table.insert(highlights, {
-      group = "Aerial" .. item.kind .. "Icon",
+      group = "Aerial" .. item.kind .. (item.scope or "") .. "Icon",
       row = row,
       col_start = string_len[spacing],
       col_end = string_len[spacing] + string_len[kind],
     })
     table.insert(highlights, {
-      group = "Aerial" .. item.kind,
+      group = "Aerial" .. item.kind .. (item.scope or ""),
       row = row,
       col_start = string_len[spacing] + string_len[kind],
       col_end = -1,

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -52,8 +52,8 @@ local function aerial_picker(opts)
     local text = vim.api.nvim_buf_get_lines(bufnr, item.lnum - 1, item.lnum, false)[1] or ""
     text = vim.trim(text)
     local columns = {
-      { icon, "Aerial" .. item.kind .. "Icon" },
-      { entry.name, "Aerial" .. item.kind },
+      { icon, "Aerial" .. item.kind .. "Icon" .. (item.scope or "") },
+      { entry.name, "Aerial" .. item.kind .. (item.scope or "") },
       text,
     }
     return displayer(columns)

--- a/tests/treesitter/elixir_spec.lua
+++ b/tests/treesitter/elixir_spec.lua
@@ -34,6 +34,7 @@ describe("treesitter elixir", function()
             kind = "Function",
             name = "private_function",
             level = 1,
+            scope = "Private",
             lnum = 10,
             col = 2,
             end_lnum = 11,


### PR DESCRIPTION
fixes #225

Implemented only the elixir private case. I thought just changing the icon wasn't enough, I had to make the text italic too. Maybe the icon should be the same color by default, this sets the icon for private symbols to NONE. I thought personally I needed all the help I could get to quickly spot the different public/private, so NONE suits me.