### PR TITLE
fix: aerial shouldn't be disabled by default in the man pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ require("aerial").setup({
     -- Ignored buftypes.
     -- Can be one of the following:
     -- false or nil - No buftypes are ignored.
-    -- "special"    - All buffers other than normal and help buffers are ignored.
+    -- "special"    - All buffers other than normal, help and man page buffers are ignored.
     -- table        - A list of buftypes to ignore. See :help buftype for the
     --                possible values.
     -- function     - A function that returns true if the buffer should be

--- a/doc/aerial.txt
+++ b/doc/aerial.txt
@@ -160,7 +160,7 @@ OPTIONS                                                           *aerial-option
         -- Ignored buftypes.
         -- Can be one of the following:
         -- false or nil - No buftypes are ignored.
-        -- "special"    - All buffers other than normal and help buffers are ignored.
+        -- "special"    - All buffers other than normal, help and man page buffers are ignored.
         -- table        - A list of buftypes to ignore. See :help buftype for the
         --                possible values.
         -- function     - A function that returns true if the buffer should be

--- a/lua/aerial/config.lua
+++ b/lua/aerial/config.lua
@@ -146,7 +146,7 @@ local default_options = {
     -- Ignored buftypes.
     -- Can be one of the following:
     -- false or nil - No buftypes are ignored.
-    -- "special"    - All buffers other than normal and help buffers are ignored.
+    -- "special"    - All buffers other than normal, help and man page buffers are ignored.
     -- table        - A list of buftypes to ignore. See :help buftype for the
     --                possible values.
     -- function     - A function that returns true if the buffer should be

--- a/lua/aerial/util.lua
+++ b/lua/aerial/util.lua
@@ -240,8 +240,9 @@ M.is_ignored_buf = function(bufnr)
   end
   if ignore.buftypes then
     local buftype = vim.api.nvim_buf_get_option(bufnr, "buftype")
+    local filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
     if ignore.buftypes == "special" then
-      if buftype ~= "" and buftype ~= "help" then
+      if buftype ~= "" and buftype ~= "help" and filetype ~= "man" then
         return true, string.format("Buftype '%s' is \"special\"", buftype)
       end
     elseif type(ignore.buftypes) == "table" then


### PR DESCRIPTION
Man pages are no longer ignored when `ignore.buftypes = "special"`.  
Allowing Aerial windows to be opened in the man pages by default.  

![image](https://user-images.githubusercontent.com/59733058/227444291-175edb2a-cd63-4588-a66c-f349a27f7f8b.png)

Aerial works beautifully well in the man pages, by the way.  
It would be a huge waste to disable this by default.
