### PR TITLE
fix: check validity of buffer in deferred callbacks

### DIFF
--- a/lua/aerial/backends/init.lua
+++ b/lua/aerial/backends/init.lua
@@ -190,6 +190,9 @@ M.set_symbols = function(bufnr, items, ctx)
       -- We need that autocmd to complete first so that it reallocates the existing aerial windows,
       -- thus the defer. It's a bit of a hack :/
       vim.defer_fn(function()
+        if not vim.api.nvim_buf_is_valid(bufnr) then
+          return
+        end
         window.maybe_open_automatic(bufnr)
       end, 15)
     end

--- a/lua/aerial/backends/lsp/callbacks.lua
+++ b/lua/aerial/backends/lsp/callbacks.lua
@@ -177,6 +177,9 @@ M.symbol_callback = function(_err, result, context, _config)
     vim.defer_fn(function()
       local r = results[bufnr]
       results[bufnr] = nil
+      if not vim.api.nvim_buf_is_valid(bufnr) then
+        return
+      end
       M.handle_symbols(r, bufnr, client.name)
     end, 100)
   end

--- a/lua/aerial/util.lua
+++ b/lua/aerial/util.lua
@@ -175,7 +175,7 @@ M.flash_highlight = function(bufnr, lnum, durationMs, hl_group)
   end
   local ns = vim.api.nvim_buf_add_highlight(bufnr, 0, hl_group, lnum - 1, 0, -1)
   local remove_highlight = function()
-    vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
+    pcall(vim.api.nvim_buf_clear_namespace, bufnr, ns, 0, -1)
   end
   vim.defer_fn(remove_highlight, durationMs)
 end

--- a/lua/aerial/window.lua
+++ b/lua/aerial/window.lua
@@ -48,6 +48,9 @@ local function create_aerial_buffer(bufnr)
     callback = function(params)
       -- Defer it so we have time to set window options and variables on the float first
       vim.defer_fn(function()
+        if not vim.api.nvim_buf_is_valid(bufnr) then
+          return
+        end
         render.update_aerial_buffer(aer_bufnr)
         M.update_all_positions(bufnr, 0)
         M.center_symbol_in_view(bufnr)


### PR DESCRIPTION
Buffer may have been :bwipeout-ed by user before the callback runs.

For example, I once ran into this error:
```
Error executing vim.schedule lua callback: ...lugged/aerial.nvim/lua/aerial/backends/lsp/callbacks.lua:46: Invalid buffer id: 39
stack traceback:
        [C]: in function 'nvim_buf_line_count'
        ...lugged/aerial.nvim/lua/aerial/backends/lsp/callbacks.lua:46: in function 'process_symbols'
        ...lugged/aerial.nvim/lua/aerial/backends/lsp/callbacks.lua:136: in function 'handle_symbols'
        ...lugged/aerial.nvim/lua/aerial/backends/lsp/callbacks.lua:180: in function ''
        vim/_editor.lua: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```