### PR TITLE
fix: use relative url for submodule definition (#264)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".github/nvim_doc_tools"]
 	path = .github/nvim_doc_tools
-	url = https://github.com/stevearc/nvim_doc_tools
+	url = ../../stevearc/nvim_doc_tools


### PR DESCRIPTION
Uses relative url for submodule so to enable users to clone from mirror site with `--recurse-submodules`.
Tested in  a site without GitHub access, using a mirror site
Tested with a normal configuration, using https://github.com as usual

Uses 2 levels of indirection (../../stevearc/nvim_doc_tools) instead of one (../nvim_doc_tools) so that people who fork aerial are not also forced to fork nvim_doc_tools.