### PR TITLE
feat: add layout.resize_to_content config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ require("aerial").setup({
     --   window - open aerial to the right/left of the current window
     placement = "window",
 
+    -- When the symbols change, resize the aerial window (within min/max constraints) to fit
+    resize_to_content = true,
+
     -- Preserve window size equality with (:help CTRL-W_=)
     preserve_equality = false,
   },

--- a/doc/aerial.txt
+++ b/doc/aerial.txt
@@ -40,6 +40,9 @@ OPTIONS                                                           *aerial-option
         --   window - open aerial to the right/left of the current window
         placement = "window",
 
+        -- When the symbols change, resize the aerial window (within min/max constraints) to fit
+        resize_to_content = true,
+
         -- Preserve window size equality with (:help CTRL-W_=)
         preserve_equality = false,
       },

--- a/lua/aerial/autocommands.lua
+++ b/lua/aerial/autocommands.lua
@@ -96,9 +96,6 @@ M.on_enter_buffer = util.throttle(function()
       or vim.tbl_count(vim.api.nvim_tabpage_list_wins(0)) == 1
     then
       vim.cmd("quit")
-    else
-      -- Hack to ignore winwidth
-      util.restore_width(0, 0)
     end
     return
   end

--- a/lua/aerial/config.lua
+++ b/lua/aerial/config.lua
@@ -26,6 +26,9 @@ local default_options = {
     --   window - open aerial to the right/left of the current window
     placement = "window",
 
+    -- When the symbols change, resize the aerial window (within min/max constraints) to fit
+    resize_to_content = true,
+
     -- Preserve window size equality with (:help CTRL-W_=)
     preserve_equality = false,
   },

--- a/lua/aerial/render.lua
+++ b/lua/aerial/render.lua
@@ -42,8 +42,11 @@ local function resize_all_wins(aer_bufnr, preferred_width, preferred_height)
       -- padding out whitespace. The gutter needs to adjust the total window
       -- size, but it doesn't take space away from the content.
       max_width = math.max(max_width, width - gutter)
-      if config.layout.resize_to_content or vim.b[aer_bufnr].aerial_width == nil then
+      if not vim.w[winid].aerial_set_width or config.layout.resize_to_content then
         vim.api.nvim_win_set_width(winid, width)
+        vim.w[winid].aerial_set_width = true
+      else
+        max_width = math.max(max_width, vim.api.nvim_win_get_width(winid))
       end
       vim.b[aer_bufnr].aerial_width = width
 

--- a/lua/aerial/render.lua
+++ b/lua/aerial/render.lua
@@ -42,8 +42,10 @@ local function resize_all_wins(aer_bufnr, preferred_width, preferred_height)
       -- padding out whitespace. The gutter needs to adjust the total window
       -- size, but it doesn't take space away from the content.
       max_width = math.max(max_width, width - gutter)
-      vim.api.nvim_win_set_width(winid, width)
-      util.save_width(aer_bufnr, width)
+      if config.layout.resize_to_content or vim.b[aer_bufnr].aerial_width == nil then
+        vim.api.nvim_win_set_width(winid, width)
+      end
+      vim.b[aer_bufnr].aerial_width = width
 
       -- Reposition floating windows
       if util.is_floating_win(winid) then

--- a/lua/aerial/util.lua
+++ b/lua/aerial/util.lua
@@ -28,22 +28,8 @@ end
 ---@param str string
 ---@return string
 M.remove_newlines = function(str)
-  return string.gsub(str, "\n", " ")
-end
-
----@param winid integer Window to restore
----@param bufnr integer Aerial buffer
-M.restore_width = function(winid, bufnr)
-  local ok, width = pcall(vim.api.nvim_buf_get_var, bufnr, "aerial_width")
-  if ok then
-    vim.api.nvim_win_set_width(winid, width)
-  end
-end
-
----@param bufnr integer
----@param width integer
-M.save_width = function(bufnr, width)
-  vim.api.nvim_buf_set_var(bufnr, "aerial_width", width)
+  local ret = string.gsub(str, "\n", " ")
+  return ret
 end
 
 ---@param winid nil|integer

--- a/lua/aerial/window.lua
+++ b/lua/aerial/window.lua
@@ -107,7 +107,10 @@ local function setup_aerial_win(src_winid, aer_winid, aer_bufnr)
   vim.api.nvim_win_set_var(src_winid, "aerial_win", aer_winid)
   -- Set the filetype only after we enter the buffer so that ftplugins behave properly
   vim.api.nvim_buf_set_option(aer_bufnr, "filetype", "aerial")
-  util.restore_width(aer_winid, aer_bufnr)
+  local width = vim.b[aer_bufnr].aerial_width
+  if width then
+    vim.api.nvim_win_set_width(aer_winid, width)
+  end
   if config.layout.preserve_equality then
     vim.cmd.wincmd({ args = { "=" } })
   end

--- a/lua/aerial/window.lua
+++ b/lua/aerial/window.lua
@@ -108,8 +108,9 @@ local function setup_aerial_win(src_winid, aer_winid, aer_bufnr)
   -- Set the filetype only after we enter the buffer so that ftplugins behave properly
   vim.api.nvim_buf_set_option(aer_bufnr, "filetype", "aerial")
   local width = vim.b[aer_bufnr].aerial_width
-  if width then
+  if width and (not vim.w[aer_winid].aerial_set_width or config.layout.resize_to_content) then
     vim.api.nvim_win_set_width(aer_winid, width)
+    vim.w[aer_winid].aerial_set_width = true
   end
   if config.layout.preserve_equality then
     vim.cmd.wincmd({ args = { "=" } })


### PR DESCRIPTION
closes #267 

This adds a new config option `layout.resize_to_content` that, when false, prevents the aerial sidebar from updating its width to grow/shrink when the length of the symbols changes.