### PR TITLE
elixir: support parameterless functions

### DIFF
--- a/queries/elixir/aerial.scm
+++ b/queries/elixir/aerial.scm
@@ -20,6 +20,7 @@
   (arguments [
               (call target: (identifier) @name)
               (binary_operator left: (call target: (identifier) @name))
+              ((identifier) @name)
    ])
   (#set! "kind" "Function")
   ) @type

--- a/tests/treesitter/elixir_spec.lua
+++ b/tests/treesitter/elixir_spec.lua
@@ -225,6 +225,15 @@ describe("treesitter elixir", function()
           },
         },
       },
+      {
+        kind = "Function",
+        name = "parameterless_function",
+        level = 0,
+        lnum = 68,
+        col = 0,
+        end_lnum = 69,
+        end_col = 3,
+      },
     })
   end)
 end)

--- a/tests/treesitter/elixir_test.exs
+++ b/tests/treesitter/elixir_test.exs
@@ -13,7 +13,7 @@ defmodule Example.Module do
   defguard public_guard(x) when is_atom(x)
 
   defguard private_guard(x) when is_atom(x)
- 
+
   defmacro public_macro() do
   end
 
@@ -63,4 +63,7 @@ defmodule StringTest do
       assert String.capitalize("HELLO") == "Hello"
     end
   end
+end
+
+def parameterless_function do
 end


### PR DESCRIPTION
it turns out elixir allows to skip the brackets for parameterless functions: aerial didn't take such functions into account so far.