### PR TITLE
fix(render): use EOL extmarks to render AerialLine

### DIFF
--- a/lua/aerial/render.lua
+++ b/lua/aerial/render.lua
@@ -15,7 +15,6 @@ end
 
 -- Resize all windows displaying this aerial buffer
 local function resize_all_wins(aer_bufnr, preferred_width, preferred_height)
-  local max_width = 0
   for _, winid in ipairs(vim.api.nvim_list_wins()) do
     if vim.api.nvim_win_get_buf(winid) == aer_bufnr then
       local relative = "editor"
@@ -41,12 +40,9 @@ local function resize_all_wins(aer_bufnr, preferred_width, preferred_height)
       -- Subtract the gutter here because it is passed back to be used for
       -- padding out whitespace. The gutter needs to adjust the total window
       -- size, but it doesn't take space away from the content.
-      max_width = math.max(max_width, width - gutter)
       if not vim.w[winid].aerial_set_width or config.layout.resize_to_content then
         vim.api.nvim_win_set_width(winid, width)
         vim.w[winid].aerial_set_width = true
-      else
-        max_width = math.max(max_width, vim.api.nvim_win_get_width(winid))
       end
       vim.b[aer_bufnr].aerial_width = width
 
@@ -73,7 +69,6 @@ local function resize_all_wins(aer_bufnr, preferred_width, preferred_height)
   if config.layout.preserve_equality then
     vim.cmd.wincmd({ args = { "=" } })
   end
-  return max_width
 end
 
 -- Update the aerial buffer from cached symbols
@@ -179,7 +174,7 @@ M.update_aerial_buffer = function(buf)
     row = row + 1
   end
 
-  local width = resize_all_wins(aer_bufnr, max_len, #lines)
+  resize_all_wins(aer_bufnr, max_len, #lines)
 
   -- Insert lines into buffer
   vim.api.nvim_buf_set_option(aer_bufnr, "modifiable", true)

--- a/lua/aerial/render.lua
+++ b/lua/aerial/render.lua
@@ -195,6 +195,7 @@ M.highlight_line = function(buf, ns, hl_group, row, col, end_col)
     end_row = end_col == -1 and (row + 1) or nil,
     hl_eol = true,
     hl_group = hl_group or "AerialLine",
+    strict = false,
   })
 end
 

--- a/lua/aerial/render.lua
+++ b/lua/aerial/render.lua
@@ -182,9 +182,6 @@ M.update_aerial_buffer = function(buf)
   local width = resize_all_wins(aer_bufnr, max_len, #lines)
 
   -- Insert lines into buffer
-  for i, line in ipairs(lines) do
-    lines[i] = util.rpad(line, width)
-  end
   vim.api.nvim_buf_set_option(aer_bufnr, "modifiable", true)
   vim.api.nvim_buf_set_lines(aer_bufnr, 0, -1, false, lines)
   vim.api.nvim_buf_set_option(aer_bufnr, "modifiable", false)
@@ -195,6 +192,15 @@ M.update_aerial_buffer = function(buf)
     vim.api.nvim_buf_add_highlight(aer_bufnr, ns, hl.group, hl.row - 1, hl.col_start, hl.col_end)
   end
   M.update_highlights(bufnr)
+end
+
+M.highlight_line = function(buf, ns, hl_group, row, col, end_col)
+  vim.api.nvim_buf_set_extmark(buf, ns, row, col, {
+    end_col = end_col ~= -1 and end_col or nil,
+    end_row = end_col == -1 and (row + 1) or nil,
+    hl_eol = true,
+    hl_group = hl_group or "AerialLine",
+  })
 end
 
 ---Update the highlighted lines in the aerial buffer
@@ -227,7 +233,7 @@ M.update_highlights = function(buf)
   if hl_mode == "last" then
     local pos = bufdata.positions[bufdata.last_win]
     if pos and (config.highlight_closest or pos.exact_symbol) then
-      vim.api.nvim_buf_add_highlight(aer_bufnr, ns, "AerialLine", pos.lnum - 1, 0, -1)
+      M.highlight_line(aer_bufnr, ns, "AerialLine", pos.lnum - 1, 0, -1)
     end
     return
   end
@@ -243,7 +249,7 @@ M.update_highlights = function(buf)
     local pos = bufdata.positions[winid]
     if config.highlight_closest or pos.exact_symbol then
       local hl_group = winid == bufdata.last_win and "AerialLine" or "AerialLineNC"
-      vim.api.nvim_buf_add_highlight(aer_bufnr, ns, hl_group, pos.lnum - 1, start_hl, end_hl)
+      M.highlight_line(aer_bufnr, ns, hl_group, pos.lnum - 1, start_hl, end_hl)
     end
     if hl_mode ~= "full_width" then
       start_hl = end_hl
@@ -257,7 +263,7 @@ M.update_highlights = function(buf)
     local cursor = vim.api.nvim_win_get_cursor(0)
     local item = data.get_or_create(0):item(cursor[1])
     if item then
-      vim.api.nvim_buf_add_highlight(bufnr, ns, "AerialLine", item.lnum - 1, 0, -1)
+      M.highlight_line(bufnr, ns, "AerialLine", item.lnum - 1, 0, -1)
     end
   end
 end


### PR DESCRIPTION
I noticed that aerial highlight lines were not always correctly rendered. Especially when using edgy, that resizes component windows automatically.

Looking at the code, I found that to make a line, you used to pad with spaces, but this is not ideal.

Extmarks can be used instead that can extend to the EOL similar to the cursor line.

This PR implements that.

All the `highlight_modes` should work the same as before, but will now always properly extend till the end of the window when needed.