### PR TITLE
feat(telescope): only reverse results when `sorting_strategy = "descending"`

### DIFF
--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -114,8 +114,10 @@ local function aerial_picker(opts)
   end
 
   -- Reverse the symbols so they have the same top-to-bottom order as in the file
-  util.tbl_reverse(results)
-  default_selection_index = #results - (default_selection_index - 1)
+  if conf.sorting_strategy == "descending" then
+    util.tbl_reverse(results)
+    default_selection_index = #results - (default_selection_index - 1)
+  end
   pickers
     .new(opts, {
       prompt_title = "Document Symbols",


### PR DESCRIPTION
results in telescope are reversed to show them in order as they appear in the document.

However, this doesn't work properly when `defaults.sorting_strategy = "ascending"`.

In that case, the table should not be reversed.

# With this PR

![image](https://github.com/stevearc/aerial.nvim/assets/292349/9fe81282-4b5f-4546-b5bb-77811cb62d15)

# Without

`aerial_picker` should be on top

![image](https://github.com/stevearc/aerial.nvim/assets/292349/65e09c68-0cbd-40f6-ac2d-988b91dd85c6)
