### PR TITLE
Add snakemake

### DIFF
--- a/queries/snakemake/aerial.scm
+++ b/queries/snakemake/aerial.scm
@@ -1,0 +1,19 @@
+(function_definition
+  name: (identifier) @name
+  (#set! "kind" "Function")
+  ) @type
+
+(class_definition
+  name: (identifier) @name
+  (#set! "kind" "Class")
+  ) @type
+
+(assignment
+  left: (_) @name
+  (#set! "kind" "Variable")
+  ) @type
+
+(rule_definition
+  name: (identifier) @name
+  (#set! "kind" "Class")
+) @type

--- a/tests/symbols/snakemake_test.json
+++ b/tests/symbols/snakemake_test.json
@@ -1,0 +1,64 @@
+[
+  {
+    "col": 0,
+    "end_col": 8,
+    "end_lnum": 2,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 1,
+    "name": "fn_1",
+    "selection_range": {
+      "col": 4,
+      "end_col": 8,
+      "end_lnum": 1,
+      "lnum": 1
+    }
+  },
+  {
+    "children": [
+      {
+        "col": 4,
+        "end_col": 12,
+        "end_lnum": 7,
+        "kind": "Function",
+        "level": 1,
+        "lnum": 6,
+        "name": "meth_1",
+        "selection_range": {
+          "col": 8,
+          "end_col": 14,
+          "end_lnum": 6,
+          "lnum": 6
+        }
+      }
+    ],
+    "col": 0,
+    "end_col": 12,
+    "end_lnum": 7,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 5,
+    "name": "cl_1",
+    "selection_range": {
+      "col": 6,
+      "end_col": 10,
+      "end_lnum": 5,
+      "lnum": 5
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 10,
+    "end_lnum": 9,
+    "kind": "Variable",
+    "level": 0,
+    "lnum": 9,
+    "name": "var",
+    "selection_range": {
+      "col": 0,
+      "end_col": 3,
+      "end_lnum": 9,
+      "lnum": 9
+    }
+  }
+]

--- a/tests/treesitter/snakemake_test.smk
+++ b/tests/treesitter/snakemake_test.smk
@@ -1,0 +1,12 @@
+rule all:
+    input:
+        "b.txt"
+    output:
+        "c.txt"
+    shell:
+        "ls -la > {output}"
+
+def f():
+    pass
+
+var = 'hi'


### PR DESCRIPTION
This adds some support for [Snakemake](https://snakemake.readthedocs.io/en/stable/). Since Snakemake is a superset of Python, this copies the existing Python `aerial.scm` and just adds the ability to navigate [rules](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html) via aerial.nvim.

I don't quite follow how to make the expected test cases in `test/symbols/`, so I copied over the Python one to see how the tests break to see if there are any clues...