### PR TITLE
Allow setting [privacy] scope from queries

### DIFF
--- a/lua/aerial/backends/treesitter/init.lua
+++ b/lua/aerial/backends/treesitter/init.lua
@@ -124,6 +124,7 @@ M.fetch_symbols_sync = function(bufnr)
       name = name,
       level = level,
       parent = parent_item,
+      scope = match.scope,
     }
     if use_selection_range then
       item.selection_range = selection_range

--- a/queries/ruby/aerial.scm
+++ b/queries/ruby/aerial.scm
@@ -4,20 +4,38 @@
   ) @type
 
 (method
-  name: (identifier) @name
+  name: (_) @name
   (#set! "kind" "Method")
   ) @type
 
-(method
-  name: (operator) @name
-  (#set! "kind" "Method")
-  ) @type
+(call
+  (identifier) @scope_switch
+  (#any-of? @scope_switch "private" "protected")
 
-(method
-  name: (setter
-    name: (identifier)) @name
-  (#set! "kind" "Method")
-  ) @type
+  (argument_list
+    (method
+      name: (_) @name
+      (#set! "kind" "Method")
+      (#set! "scope" "private")
+      ) @type
+    )
+  )
+
+(body_statement
+  (identifier) @scope @later_scope
+  (#any-of? @scope "private" "protected")
+  .
+  [
+   (_)
+   ((identifier) @later_scope (#not-eq? @later_scope "public"))
+   ]*
+  .
+  (method
+    name: (_) @name
+    (#set! "kind" "Method")
+    (#set! "scope" "private")
+    ) @type
+  )
 
 (singleton_method
   object: [(constant) (self) (identifier)] @receiver

--- a/tests/symbols/ruby_test.json
+++ b/tests/symbols/ruby_test.json
@@ -385,5 +385,193 @@
       "end_lnum": 48,
       "lnum": 38
     }
+  },
+  {
+    "children": [
+      {
+        "kind": "Method",
+        "name": "inline_private",
+        "level": 1,
+        "scope": "private",
+        "lnum": 51,
+        "col": 10,
+        "end_lnum": 52,
+        "end_col": 5,
+        "selection_range": {
+          "lnum": 51,
+          "col": 14,
+          "end_lnum": 51,
+          "end_col": 28
+        }
+      },
+      {
+        "kind": "Method",
+        "name": "public_1",
+        "level": 1,
+        "lnum": 54,
+        "col": 2,
+        "end_lnum": 55,
+        "end_col": 5,
+        "selection_range": {
+          "lnum": 54,
+          "col": 6,
+          "end_lnum": 54,
+          "end_col": 14
+        }
+      },
+      {
+        "kind": "Method",
+        "name": "private_1",
+        "level": 1,
+        "scope": "private",
+        "lnum": 58,
+        "col": 2,
+        "end_lnum": 59,
+        "end_col": 5,
+        "selection_range": {
+          "lnum": 58,
+          "col": 6,
+          "end_lnum": 58,
+          "end_col": 15
+        }
+      },
+      {
+        "kind": "Method",
+        "name": "protected_1",
+        "level": 1,
+        "scope": "private",
+        "lnum": 64,
+        "col": 2,
+        "end_lnum": 65,
+        "end_col": 5,
+        "selection_range": {
+          "lnum": 64,
+          "col": 6,
+          "end_lnum": 64,
+          "end_col": 17
+        }
+      },
+      {
+        "kind": "Class",
+        "name": "DoNotBreakScope",
+        "level": 1,
+        "lnum": 69,
+        "col": 2,
+        "end_lnum": 70,
+        "end_col": 5,
+        "selection_range": {
+          "lnum": 69,
+          "col": 8,
+          "end_lnum": 69,
+          "end_col": 23
+        }
+      },
+      {
+        "kind": "Method",
+        "name": "protected_2",
+        "level": 1,
+        "scope": "private",
+        "lnum": 73,
+        "col": 2,
+        "end_lnum": 74,
+        "end_col": 5,
+        "selection_range": {
+          "lnum": 73,
+          "col": 6,
+          "end_lnum": 73,
+          "end_col": 17
+        }
+      },
+      {
+        "kind": "Method",
+        "name": "inline_public",
+        "level": 1,
+        "lnum": 76,
+        "col": 9,
+        "end_lnum": 77,
+        "end_col": 5,
+        "selection_range": {
+          "lnum": 76,
+          "col": 13,
+          "end_lnum": 76,
+          "end_col": 26
+        }
+      },
+      {
+        "kind": "Method",
+        "name": "protected_3",
+        "level": 1,
+        "scope": "private",
+        "lnum": 79,
+        "col": 2,
+        "end_lnum": 80,
+        "end_col": 5,
+        "selection_range": {
+          "lnum": 79,
+          "col": 6,
+          "end_lnum": 79,
+          "end_col": 17
+        }
+      },
+      {
+        "kind": "Method",
+        "name": "public_2",
+        "level": 1,
+        "lnum": 83,
+        "col": 2,
+        "end_lnum": 84,
+        "end_col": 5,
+        "selection_range": {
+          "lnum": 83,
+          "col": 6,
+          "end_lnum": 83,
+          "end_col": 14
+        }
+      },
+      {
+        "kind": "Method",
+        "name": "public_setter=",
+        "level": 1,
+        "lnum": 86,
+        "col": 2,
+        "end_lnum": 87,
+        "end_col": 5,
+        "selection_range": {
+          "lnum": 86,
+          "col": 6,
+          "end_lnum": 86,
+          "end_col": 20
+        }
+      },
+      {
+        "kind": "Method",
+        "name": "private_setter=",
+        "level": 1,
+        "scope": "private",
+        "lnum": 90,
+        "col": 2,
+        "end_lnum": 91,
+        "end_col": 5,
+        "selection_range": {
+          "lnum": 90,
+          "col": 6,
+          "end_lnum": 90,
+          "end_col": 21
+        }
+      }
+    ],
+    "kind": "Class",
+    "name": "Privateers",
+    "level": 0,
+    "lnum": 50,
+    "col": 0,
+    "end_lnum": 92,
+    "end_col": 3,
+    "selection_range": {
+      "lnum": 50,
+      "col": 6,
+      "end_lnum": 50,
+      "end_col": 16
+    }
   }
 ]

--- a/tests/treesitter/ruby_test.rb
+++ b/tests/treesitter/ruby_test.rb
@@ -46,3 +46,47 @@ context "Shoulda Context" do
   end
   should_not validate_presence_of(:title)
 end
+
+class Privateers
+  private def inline_private
+  end
+
+  def public_1
+  end
+
+  private
+  def private_1
+  end
+
+  acts_as_state_machine
+
+  protected
+  def protected_1
+  end
+
+  attr_reader :test
+
+  class DoNotBreakScope
+  end
+
+  # Some comment
+  def protected_2
+  end
+
+  public def inline_public
+  end
+
+  def protected_3
+  end
+
+  public
+  def public_2
+  end
+
+  def public_setter=(val)
+  end
+
+  private
+  def private_setter=(val)
+  end
+end


### PR DESCRIPTION
This has direct impact on highlighting. If scope is set and set to anything but "public", highlighter will use a separate highlight for the corresponding entry. This was previously used by Elixir extension by manually processing nodes.

Elixir extension processing is removed, its queries updated, and fixed to consider not just `defp`, but also `defguardp` and `defmacrop` as private.

Ruby queries are updated to deal with both predicate and statement versions of scope setting. The query is kinda brittle still, as anything unexpected in between methods definitions will break it. "Not" match would solve the problem, but treesitter doesn't provide one. A custom predicate might be a way to go, but better is the enemy of good, so I'm stopping here.