### PR TITLE
Added aerial queries for objdump

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,13 @@ jobs:
         run: |
           bash ./run_tests.sh
 
+      - name: Check for changes
+        run: |
+          git add tests
+          git diff --quiet --staged || echo "Changes to snapshot file detected. Run 'make update_snapshots' and commit the changes"
+          git diff --stat --staged
+          git diff --quiet --staged
+
   update_docs:
     name: Update docs
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ In addition, you will need to have either Treesitter or a working LSP client. Yo
 - make
 - markdown
 - norg
+- objdump
 - org
 - php
 - proto

--- a/queries/objdump/aerial.scm
+++ b/queries/objdump/aerial.scm
@@ -1,0 +1,7 @@
+(disassembly_section_label
+  (identifier) @name
+  (#set! "kind" "Interface")) @type
+
+(disassembly_section
+  (identifier) @name
+  (#set! "kind" "Function")) @type

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -5,6 +5,7 @@ vim.bo.swapfile = false
 vim.filetype.add({
   extension = {
     norg = "norg", -- Neovim doesn't have built-in norg filetype detection
+    objdump = "objdump", -- Neovim doesn't have built-in USD filetype detection
     usd = "usd", -- Neovim doesn't have built-in USD filetype detection
     usda = "usd", -- Neovim doesn't have built-in USD filetype detection
     smk = "snakemake", -- Neovim doesn't have built-in Snakemake filetype detection

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -3,12 +3,13 @@ vim.cmd([[set runtimepath+=.]])
 vim.o.swapfile = false
 vim.bo.swapfile = false
 vim.filetype.add({
+  -- Neovim doesn't have built-in filetype detection for these filetypes
   extension = {
-    norg = "norg", -- Neovim doesn't have built-in norg filetype detection
-    objdump = "objdump", -- Neovim doesn't have built-in USD filetype detection
-    usd = "usd", -- Neovim doesn't have built-in USD filetype detection
-    usda = "usd", -- Neovim doesn't have built-in USD filetype detection
-    smk = "snakemake", -- Neovim doesn't have built-in Snakemake filetype detection
+    norg = "norg",
+    objdump = "objdump",
+    usd = "usd",
+    usda = "usd",
+    smk = "snakemake",
   },
 })
 

--- a/tests/symbols/objdump_test.json
+++ b/tests/symbols/objdump_test.json
@@ -1,0 +1,32 @@
+[
+  {
+    "col": 0,
+    "end_col": 29,
+    "end_lnum": 1,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 1,
+    "name": ".text",
+    "selection_range": {
+      "col": 23,
+      "end_col": 28,
+      "end_lnum": 1,
+      "lnum": 1
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 91,
+    "end_lnum": 9,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 3,
+    "name": "<engine::world::World::createEntity()>",
+    "selection_range": {
+      "col": 17,
+      "end_col": 55,
+      "end_lnum": 3,
+      "lnum": 3
+    }
+  }
+]

--- a/tests/treesitter/objdump_test.objdump
+++ b/tests/treesitter/objdump_test.objdump
@@ -1,0 +1,9 @@
+Disassembly of section .text:
+
+0000000000000000 <engine::world::World::createEntity()> (File Offset: 0x70):
+_ZN6engine5world5World12createEntityEv():
+/home/selecaoone/repositories/jumpy/engine/src/lib/world.cpp:14
+  0:	48 89 f8                                              	mov    rax,rdi
+_ZNKSt15__uniq_ptr_implIN6engine13entityManager13EntityManagerESt14default_deleteIS2_EE6_M_ptrEv():
+/opt/rh/devtoolset-9/root/usr/include/c++/9/bits/unique_ptr.h:154
+  3:	48 8b 4f 40                                           	mov    rcx,QWORD PTR [rdi+0x40]


### PR DESCRIPTION
Now that https://github.com/neovim/neovim/pull/23608 and https://github.com/nvim-treesitter/nvim-treesitter/commit/0179a89656b4ce395a4487c07ae385b8425524ae merged, objdump files are recognized in Neovim with tree-sitter support. Adding to aerial.nvim as well.

![aerial nvim_objdump_demo](https://github.com/stevearc/aerial.nvim/assets/10103049/8afecc10-2cd9-45e2-b172-9db09d7c486c)

Since objdump files aren't really code, I wasn't sure what the preferred header would be. So I just chose `"Interface"` and `"Function"`. Open to suggestions, there.