### PR TITLE
Chores: Update markdown expectations, regenerate ruby symbols, enable nvim-treesitter main testing

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,14 +1,26 @@
 #!/bin/bash
 set -e
 
-if [ "$1" = "--update" ]; then
+NVIM_TREESITTER_BRANCH='master'
+
+for arg in "$@"; do
   shift
-  export UPDATE_SYMBOLS=1
-  if ! command -v jq >/dev/null; then
-    echo "jq is required for --update. Please install jq"
-    exit 1
-  fi
-fi
+  case "$arg" in
+    '--update')
+      export UPDATE_SYMBOLS=1
+      if ! command -v jq >/dev/null; then
+        echo "jq is required for --update. Please install jq"
+        exit 1
+      fi
+      ;;
+    '--test-main')
+      NVIM_TREESITTER_BRANCH='main'
+      ;;
+    *)
+      set -- "$@" "$arg"
+      ;;
+  esac
+done
 
 mkdir -p ".testenv/config/nvim"
 mkdir -p ".testenv/data/nvim"
@@ -19,21 +31,20 @@ PLUGINS=".testenv/data/nvim/site/pack/plugins/start"
 
 if [ ! -e "$PLUGINS/plenary.nvim" ]; then
   git clone --depth=1 https://github.com/nvim-lua/plenary.nvim.git "$PLUGINS/plenary.nvim"
-else
-  (cd "$PLUGINS/plenary.nvim" && git pull)
 fi
 if [ ! -e "$PLUGINS/nvim-treesitter" ]; then
-  git clone --depth=1 https://github.com/nvim-treesitter/nvim-treesitter.git "$PLUGINS/nvim-treesitter"
-else
-  (cd "$PLUGINS/nvim-treesitter" && git pull)
+  git clone --depth=1 --no-single-branch https://github.com/nvim-treesitter/nvim-treesitter.git "$PLUGINS/nvim-treesitter"
 fi
 
-XDG_CONFIG_HOME=".testenv/config" \
-  XDG_DATA_HOME=".testenv/data" \
-  XDG_STATE_HOME=".testenv/state" \
-  XDG_RUNTIME_DIR=".testenv/run" \
-  XDG_CACHE_HOME=".testenv/cache" \
-  nvim --headless -u tests/minimal_init.lua \
-  -c "TSUpdateSync" \
-  -c "PlenaryBustedDirectory ${1-tests} { minimal_init = './tests/minimal_init.lua' }"
+(cd "$PLUGINS/plenary.nvim" && git pull)
+(cd "$PLUGINS/nvim-treesitter" && git checkout ${NVIM_TREESITTER_BRANCH} && git pull)
+
+export XDG_CONFIG_HOME=".testenv/config"
+export XDG_DATA_HOME=".testenv/data"
+export XDG_STATE_HOME=".testenv/state"
+export XDG_RUNTIME_DIR=".testenv/run"
+export XDG_CACHE_HOME=".testenv/cache"
+
+nvim --headless -u tests/minimal_init.lua \
+  -c "RunTests ${1-tests}"
 echo "Success"

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -37,9 +37,22 @@ if master_nvim_ts then
     )
   end, { nargs = "?" })
 else
+  -- Use compiler that includes c++14 features by default
+  -- If `cc` doesn't implement those, override it for tests run with
+  -- `CC=gcc-13 ./run_tests.sh`
+  local parser_config = require("nvim-treesitter.parsers").configs
+  parser_config.norg = {
+    install_info = {
+      url = "https://github.com/nvim-neorg/tree-sitter-norg",
+      files = { "src/parser.c", "src/scanner.cc" },
+      branch = "main",
+    },
+    tier = 3,
+  }
+
   vim.api.nvim_create_user_command("RunTests", function(opts)
     local path = opts.fargs[1] or "tests"
-    require("nvim-treesitter.install").install("all", { skip = { installed = true } }, function()
+    require("nvim-treesitter.install").install(langs, { skip = { installed = true } }, function()
       vim.schedule(function()
         require("plenary.test_harness").test_directory(
           path,

--- a/tests/navigation_spec.lua
+++ b/tests/navigation_spec.lua
@@ -53,7 +53,7 @@ a.describe("navigation", function()
       vim.api.nvim_win_set_cursor(0, { 1, 0 })
       aerial.select({ index = 2 })
       local cursor = vim.api.nvim_win_get_cursor(0)
-      assert.are.same({ 3, 1 }, cursor)
+      assert.are.same({ 3, 2 }, cursor)
     end)
 
     a.it("in aerial window jumps to location", function()
@@ -63,7 +63,7 @@ a.describe("navigation", function()
       assert.equals("aerial", vim.bo.filetype)
       aerial.select({ index = 2 })
       local cursor = vim.api.nvim_win_get_cursor(0)
-      assert.are.same({ 3, 1 }, cursor)
+      assert.are.same({ 3, 2 }, cursor)
     end)
 
     a.it("in aerial window uses cursor position as index", function()
@@ -75,7 +75,7 @@ a.describe("navigation", function()
       vim.api.nvim_win_set_cursor(0, { 3, 0 })
       aerial.select()
       local cursor = vim.api.nvim_win_get_cursor(0)
-      assert.are.same({ 5, 1 }, cursor)
+      assert.are.same({ 5, 2 }, cursor)
     end)
 
     a.it("doesn't have to jump", function()
@@ -92,7 +92,7 @@ a.describe("navigation", function()
       assert.equals("aerial", vim.bo.filetype)
       -- The source window cursor should be updated
       local cursor = vim.api.nvim_win_get_cursor(winid)
-      assert.are.same({ 5, 1 }, cursor)
+      assert.are.same({ 5, 2 }, cursor)
     end)
 
     a.it("can open a new split when jumping", function()
@@ -111,7 +111,7 @@ a.describe("navigation", function()
       -- Source window cursor should be the same
       assert.are.same({ 1, 0 }, vim.api.nvim_win_get_cursor(winid))
       -- Split window cursor should be updated
-      assert.are.same({ 5, 1 }, vim.api.nvim_win_get_cursor(0))
+      assert.are.same({ 5, 2 }, vim.api.nvim_win_get_cursor(0))
     end)
   end)
 
@@ -121,7 +121,7 @@ a.describe("navigation", function()
       vim.api.nvim_win_set_cursor(0, { 1, 2 })
       window.update_position() -- Not sure why the CursorMoved autocmd doesn't fire
       aerial.next()
-      assert.are.same({ 3, 2 }, vim.api.nvim_win_get_cursor(0))
+      assert.are.same({ 3, 3 }, vim.api.nvim_win_get_cursor(0))
     end)
 
     a.it("can go to next N symbol", function()
@@ -129,7 +129,7 @@ a.describe("navigation", function()
       vim.api.nvim_win_set_cursor(0, { 1, 2 })
       window.update_position() -- Not sure why the CursorMoved autocmd doesn't fire
       aerial.next(2)
-      assert.are.same({ 5, 2 }, vim.api.nvim_win_get_cursor(0))
+      assert.are.same({ 5, 3 }, vim.api.nvim_win_get_cursor(0))
     end)
 
     a.it("can go to prev symbol", function()
@@ -137,7 +137,7 @@ a.describe("navigation", function()
       vim.api.nvim_win_set_cursor(0, { 3, 2 })
       window.update_position() -- Not sure why the CursorMoved autocmd doesn't fire
       aerial.prev()
-      assert.are.same({ 1, 1 }, vim.api.nvim_win_get_cursor(0))
+      assert.are.same({ 1, 2 }, vim.api.nvim_win_get_cursor(0))
     end)
 
     a.it("can go to prev N symbol", function()
@@ -145,7 +145,7 @@ a.describe("navigation", function()
       vim.api.nvim_win_set_cursor(0, { 5, 2 })
       window.update_position() -- Not sure why the CursorMoved autocmd doesn't fire
       aerial.prev(2)
-      assert.are.same({ 1, 1 }, vim.api.nvim_win_get_cursor(0))
+      assert.are.same({ 1, 2 }, vim.api.nvim_win_get_cursor(0))
     end)
 
     a.it("can go up and backwards in the tree", function()
@@ -153,7 +153,7 @@ a.describe("navigation", function()
       vim.api.nvim_win_set_cursor(0, { 5, 2 })
       window.update_position() -- Not sure why the CursorMoved autocmd doesn't fire
       aerial.prev_up()
-      assert.are.same({ 1, 1 }, vim.api.nvim_win_get_cursor(0))
+      assert.are.same({ 1, 2 }, vim.api.nvim_win_get_cursor(0))
     end)
 
     a.it("can go up and forwards in the tree", function()
@@ -161,7 +161,7 @@ a.describe("navigation", function()
       vim.api.nvim_win_set_cursor(0, { 3, 2 })
       window.update_position() -- Not sure why the CursorMoved autocmd doesn't fire
       aerial.next_up()
-      assert.are.same({ 7, 1 }, vim.api.nvim_win_get_cursor(0))
+      assert.are.same({ 7, 2 }, vim.api.nvim_win_get_cursor(0))
     end)
   end)
 end)

--- a/tests/symbols/markdown_test.json
+++ b/tests/symbols/markdown_test.json
@@ -10,7 +10,7 @@
         "lnum": 3,
         "name": "Title 2",
         "selection_range": {
-          "col": 2,
+          "col": 3,
           "end_col": 10,
           "end_lnum": 3,
           "lnum": 3
@@ -25,7 +25,7 @@
     "lnum": 1,
     "name": "Title 1",
     "selection_range": {
-      "col": 1,
+      "col": 2,
       "end_col": 9,
       "end_lnum": 1,
       "lnum": 1
@@ -44,7 +44,7 @@
             "lnum": 13,
             "name": "Title 5",
             "selection_range": {
-              "col": 4,
+              "col": 5,
               "end_col": 12,
               "end_lnum": 13,
               "lnum": 13
@@ -59,7 +59,7 @@
         "lnum": 7,
         "name": "Title 4",
         "selection_range": {
-          "col": 3,
+          "col": 4,
           "end_col": 11,
           "end_lnum": 7,
           "lnum": 7
@@ -74,7 +74,7 @@
     "lnum": 5,
     "name": "Title 3",
     "selection_range": {
-      "col": 1,
+      "col": 2,
       "end_col": 9,
       "end_lnum": 5,
       "lnum": 5

--- a/tests/symbols/ruby_test.json
+++ b/tests/symbols/ruby_test.json
@@ -389,189 +389,189 @@
   {
     "children": [
       {
-        "kind": "Method",
-        "name": "inline_private",
-        "level": 1,
-        "scope": "private",
-        "lnum": 51,
         "col": 10,
-        "end_lnum": 52,
         "end_col": 5,
+        "end_lnum": 52,
+        "kind": "Method",
+        "level": 1,
+        "lnum": 51,
+        "name": "inline_private",
+        "scope": "private",
         "selection_range": {
-          "lnum": 51,
           "col": 14,
+          "end_col": 28,
           "end_lnum": 51,
-          "end_col": 28
+          "lnum": 51
         }
       },
       {
+        "col": 2,
+        "end_col": 5,
+        "end_lnum": 55,
         "kind": "Method",
-        "name": "public_1",
         "level": 1,
         "lnum": 54,
-        "col": 2,
-        "end_lnum": 55,
-        "end_col": 5,
+        "name": "public_1",
         "selection_range": {
-          "lnum": 54,
           "col": 6,
+          "end_col": 14,
           "end_lnum": 54,
-          "end_col": 14
+          "lnum": 54
         }
       },
       {
-        "kind": "Method",
-        "name": "private_1",
-        "level": 1,
-        "scope": "private",
-        "lnum": 58,
         "col": 2,
+        "end_col": 5,
         "end_lnum": 59,
-        "end_col": 5,
-        "selection_range": {
-          "lnum": 58,
-          "col": 6,
-          "end_lnum": 58,
-          "end_col": 15
-        }
-      },
-      {
         "kind": "Method",
-        "name": "protected_1",
         "level": 1,
+        "lnum": 58,
+        "name": "private_1",
         "scope": "private",
-        "lnum": 64,
-        "col": 2,
-        "end_lnum": 65,
-        "end_col": 5,
         "selection_range": {
-          "lnum": 64,
           "col": 6,
-          "end_lnum": 64,
-          "end_col": 17
+          "end_col": 15,
+          "end_lnum": 58,
+          "lnum": 58
         }
       },
       {
+        "col": 2,
+        "end_col": 5,
+        "end_lnum": 65,
+        "kind": "Method",
+        "level": 1,
+        "lnum": 64,
+        "name": "protected_1",
+        "scope": "private",
+        "selection_range": {
+          "col": 6,
+          "end_col": 17,
+          "end_lnum": 64,
+          "lnum": 64
+        }
+      },
+      {
+        "col": 2,
+        "end_col": 5,
+        "end_lnum": 70,
         "kind": "Class",
-        "name": "DoNotBreakScope",
         "level": 1,
         "lnum": 69,
-        "col": 2,
-        "end_lnum": 70,
-        "end_col": 5,
+        "name": "DoNotBreakScope",
         "selection_range": {
-          "lnum": 69,
           "col": 8,
+          "end_col": 23,
           "end_lnum": 69,
-          "end_col": 23
+          "lnum": 69
         }
       },
       {
-        "kind": "Method",
-        "name": "protected_2",
-        "level": 1,
-        "scope": "private",
-        "lnum": 73,
         "col": 2,
-        "end_lnum": 74,
         "end_col": 5,
+        "end_lnum": 74,
+        "kind": "Method",
+        "level": 1,
+        "lnum": 73,
+        "name": "protected_2",
+        "scope": "private",
         "selection_range": {
-          "lnum": 73,
           "col": 6,
+          "end_col": 17,
           "end_lnum": 73,
-          "end_col": 17
+          "lnum": 73
         }
       },
       {
+        "col": 9,
+        "end_col": 5,
+        "end_lnum": 77,
         "kind": "Method",
-        "name": "inline_public",
         "level": 1,
         "lnum": 76,
-        "col": 9,
-        "end_lnum": 77,
-        "end_col": 5,
+        "name": "inline_public",
         "selection_range": {
-          "lnum": 76,
           "col": 13,
+          "end_col": 26,
           "end_lnum": 76,
-          "end_col": 26
+          "lnum": 76
         }
       },
       {
-        "kind": "Method",
-        "name": "protected_3",
-        "level": 1,
-        "scope": "private",
-        "lnum": 79,
         "col": 2,
-        "end_lnum": 80,
         "end_col": 5,
+        "end_lnum": 80,
+        "kind": "Method",
+        "level": 1,
+        "lnum": 79,
+        "name": "protected_3",
+        "scope": "private",
         "selection_range": {
-          "lnum": 79,
           "col": 6,
+          "end_col": 17,
           "end_lnum": 79,
-          "end_col": 17
+          "lnum": 79
         }
       },
       {
+        "col": 2,
+        "end_col": 5,
+        "end_lnum": 84,
         "kind": "Method",
-        "name": "public_2",
         "level": 1,
         "lnum": 83,
-        "col": 2,
-        "end_lnum": 84,
-        "end_col": 5,
+        "name": "public_2",
         "selection_range": {
-          "lnum": 83,
           "col": 6,
+          "end_col": 14,
           "end_lnum": 83,
-          "end_col": 14
+          "lnum": 83
         }
       },
       {
+        "col": 2,
+        "end_col": 5,
+        "end_lnum": 87,
         "kind": "Method",
-        "name": "public_setter=",
         "level": 1,
         "lnum": 86,
-        "col": 2,
-        "end_lnum": 87,
-        "end_col": 5,
+        "name": "public_setter=",
         "selection_range": {
-          "lnum": 86,
           "col": 6,
+          "end_col": 20,
           "end_lnum": 86,
-          "end_col": 20
+          "lnum": 86
         }
       },
       {
-        "kind": "Method",
-        "name": "private_setter=",
-        "level": 1,
-        "scope": "private",
-        "lnum": 90,
         "col": 2,
-        "end_lnum": 91,
         "end_col": 5,
+        "end_lnum": 91,
+        "kind": "Method",
+        "level": 1,
+        "lnum": 90,
+        "name": "private_setter=",
+        "scope": "private",
         "selection_range": {
-          "lnum": 90,
           "col": 6,
+          "end_col": 21,
           "end_lnum": 90,
-          "end_col": 21
+          "lnum": 90
         }
       }
     ],
+    "col": 0,
+    "end_col": 3,
+    "end_lnum": 92,
     "kind": "Class",
-    "name": "Privateers",
     "level": 0,
     "lnum": 50,
-    "col": 0,
-    "end_lnum": 92,
-    "end_col": 3,
+    "name": "Privateers",
     "selection_range": {
-      "lnum": 50,
       "col": 6,
+      "end_col": 16,
       "end_lnum": 50,
-      "end_col": 16
+      "lnum": 50
     }
   }
 ]


### PR DESCRIPTION
# Markdown expectations

Recent update to nvim-treesitter breaks aerial.nvim tests.
Specifically:
- https://github.com/nvim-treesitter/nvim-treesitter/commit/96f55f30433
- https://github.com/MDeiml/tree-sitter-markdown/commit/cd705f15912

# Ruby symbols

Prior version held a bunch of data written by hand. This commit updates
it to avoid false alarms when generating symbols for new or updated
queries.

Expectations are not changed, only the order of keys in individual
tables was updated.

# Testing against nvim-treesitter main branch

While nvim-treesitter is not a strict requirement for aerial.nvim, it
is used to install parsers and it updates nvim default language to
parser assignments with practical values. This commit adds an ability to
run tests against `main` branch by providing `--test-main` option to
`run_tests.sh`.