### PR TITLE
Cache aerial tree-sitter queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ hi AerialGuide2 guifg=Blue
 - [nav_open()](doc/api.md#nav_open)
 - [nav_close()](doc/api.md#nav_close)
 - [nav_toggle()](doc/api.md#nav_toggle)
+- [treesitter_clear_query_cache()](doc/api.md#treesitter_clear_query_cache)
 - [sync_folds(bufnr)](doc/api.md#sync_foldsbufnr)
 - [info()](doc/api.md#info)
 - [num_symbols(bufnr)](doc/api.md#num_symbolsbufnr)

--- a/doc/aerial.txt
+++ b/doc/aerial.txt
@@ -629,6 +629,10 @@ nav_toggle()                                                   *aerial.nav_toggl
     Toggle the nav windows open/closed
 
 
+treesitter_clear_query_cache()               *aerial.treesitter_clear_query_cache*
+    Clear aerial's tree-sitter query cache
+
+
 sync_folds({bufnr})                                            *aerial.sync_folds*
     Sync code folding with the current tree state.
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -32,6 +32,7 @@
 - [nav_open()](#nav_open)
 - [nav_close()](#nav_close)
 - [nav_toggle()](#nav_toggle)
+- [treesitter_clear_query_cache()](#treesitter_clear_query_cache)
 - [sync_folds(bufnr)](#sync_foldsbufnr)
 - [info()](#info)
 - [num_symbols(bufnr)](#num_symbolsbufnr)
@@ -324,6 +325,12 @@ Close the nav windows
 
 `nav_toggle()` \
 Toggle the nav windows open/closed
+
+
+## treesitter_clear_query_cache()
+
+`treesitter_clear_query_cache()` \
+Clear aerial's tree-sitter query cache
 
 
 ## sync_folds(bufnr)

--- a/lua/aerial/backends/treesitter/helpers.lua
+++ b/lua/aerial/backends/treesitter/helpers.lua
@@ -1,4 +1,10 @@
 local M = {}
+local query_cache = {}
+
+--@note Clear query cache, forcing reload
+M.clear_query_cache = function()
+  query_cache = {}
+end
 
 ---@param start_node TSNode
 ---@param end_node TSNode
@@ -39,16 +45,27 @@ end
 if vim.treesitter.query.get == nil then
   ---@param lang string
   ---@return Query|nil
-  M.get_query = function(lang)
+  M.load_query = function(lang)
     ---@diagnostic disable-next-line: deprecated
     return vim.treesitter.query.get_query(lang, "aerial")
   end
 else
   ---@param lang string
   ---@return Query|nil
-  M.get_query = function(lang)
+  M.load_query = function(lang)
     return vim.treesitter.query.get(lang, "aerial")
   end
+end
+
+---@param lang string
+---@return Query|nil
+---@note caches queries to avoid filesystem hits on neovim 0.9+
+M.get_query = function(lang)
+  if not query_cache[lang] then
+    query_cache[lang] = { query = M.load_query(lang) }
+  end
+
+  return query_cache[lang].query
 end
 
 ---@param lang string

--- a/lua/aerial/init.lua
+++ b/lua/aerial/init.lua
@@ -459,6 +459,9 @@ M.nav_close = lazy("nav_view", "close")
 ---Toggle the nav windows open/closed
 M.nav_toggle = lazy("nav_view", "toggle")
 
+---Clear aerial's tree-sitter query cache
+M.treesitter_clear_query_cache = lazy("backends.treesitter.helpers", "clear_query_cache")
+
 ---Sync code folding with the current tree state.
 ---@param bufnr? integer
 ---@note


### PR DESCRIPTION
When moving away from nvim-treesitter helpers, I overlooked the caching they were performing. This means that currently on every symbols refetch, neovim scans filesystem and gets all queries. Definitely useful when writing new queries, but slow nonetheless.

This commit introduces a simple query cache and an API method to clear said cache. With this, performance should improve, yet a way to iterate over query design remains accessible.