### PR TITLE
fix: remove extra double quotes for fzf prompt

### DIFF
--- a/autoload/aerial.vim
+++ b/autoload/aerial.vim
@@ -6,7 +6,7 @@ function! aerial#fzf() abort
 	call fzf#run(fzf#wrap({
 				\ 'source': l:labels,
 				\ 'sink': funcref('aerial#goto_symbol'),
-				\ 'options': ['--prompt="Document symbols: "', '--layout=reverse-list'],
+				\ 'options': ['--prompt=Document symbols: ', '--layout=reverse-list'],
 				\ }))
 endfunction
 


### PR DESCRIPTION
Remove extra double quotes around the fzf prompt which seems to be unecessary.
Without this fix merged the fzf prompt looks like this
![image](https://github.com/stevearc/aerial.nvim/assets/56352048/f5f5d759-054e-4c0e-92b8-84d0a2c29ce7)
With this fix merged the fzf prompt will look something like this without double quotes
![image](https://github.com/stevearc/aerial.nvim/assets/56352048/9f2c3cca-0ae5-4a48-a7d8-8669d67533d1)
