### PR TITLE
feat(telescope): Save position into jumplist before 'edit' action

### DIFF
--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -128,6 +128,7 @@ local function aerial_picker(opts)
       default_selection_index = default_selection_index,
       sorter = conf.generic_sorter(opts),
       previewer = conf.qflist_previewer(opts),
+      push_cursor_on_edit = true,
     })
     :find()
 end


### PR DESCRIPTION
NOTE: This PR is DIFFERENT from https://github.com/stevearc/aerial.nvim/pull/305 - this PR touches the **telescope extension**.

Suppose my cursor is on line 24, and then I open the aerial telescope window.

Then I select a symbol and jump to it.

If I press `Ctrl + o`, then I want to jump back to line 24.

This PR implements this feature.

Tested locally, and it works well for me!