### PR TITLE
Add basic support for navigating zig files.

### DIFF
--- a/queries/zig/aerial.scm
+++ b/queries/zig/aerial.scm
@@ -9,8 +9,24 @@
             ))))
     )
 
+(Decl
+    (VarDecl
+      variable_type_function: (IDENTIFIER) @name
+      (#set! "kind" "Struct")
+      (_
+        (_
+          (ContainerDecl
+            (ContainerDeclType "union") @symbol
+            ))))
+    )
+
 (FnProto
   function: (IDENTIFIER) @name
   (#set! "kind" "Function")
   ) @symbol
 
+
+(TestDecl
+  (STRINGLITERALSINGLE) @name
+  (#set! "kind" "Function")
+  ) @symbol

--- a/queries/zig/aerial.scm
+++ b/queries/zig/aerial.scm
@@ -1,0 +1,16 @@
+(FnProto
+  function: (IDENTIFIER) @name
+  (#set! "kind" "Function")
+  ) @symbol
+
+(Decl
+    (VarDecl
+      variable_type_function: (IDENTIFIER) @name
+      (#set! "kind" "Struct")
+      (_
+        (_
+          (ContainerDecl
+            (ContainerDeclType "struct")
+            )))) @symbol
+    )
+

--- a/queries/zig/aerial.scm
+++ b/queries/zig/aerial.scm
@@ -1,8 +1,3 @@
-(FnProto
-  function: (IDENTIFIER) @name
-  (#set! "kind" "Function")
-  ) @symbol
-
 (Decl
     (VarDecl
       variable_type_function: (IDENTIFIER) @name
@@ -10,7 +5,12 @@
       (_
         (_
           (ContainerDecl
-            (ContainerDeclType "struct")
-            )))) @symbol
+            (ContainerDeclType "struct") @symbol
+            ))))
     )
+
+(FnProto
+  function: (IDENTIFIER) @name
+  (#set! "kind" "Function")
+  ) @symbol
 

--- a/tests/symbols/zig_test.json
+++ b/tests/symbols/zig_test.json
@@ -1,0 +1,62 @@
+[
+  {
+    "col": 0,
+    "end_col": 16,
+    "end_lnum": 1,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 1,
+    "name": "myFunc",
+    "selection_range": {
+      "col": 3,
+      "end_col": 9,
+      "end_lnum": 1,
+      "lnum": 1
+    }
+  },
+  {
+    "col": 17,
+    "end_col": 23,
+    "end_lnum": 5,
+    "kind": "Struct",
+    "level": 0,
+    "lnum": 5,
+    "name": "MyStruct",
+    "selection_range": {
+      "col": 6,
+      "end_col": 14,
+      "end_lnum": 5,
+      "lnum": 5
+    }
+  },
+  {
+    "col": 22,
+    "end_col": 33,
+    "end_lnum": 9,
+    "kind": "Struct",
+    "level": 0,
+    "lnum": 9,
+    "name": "MyTaggedUnion",
+    "selection_range": {
+      "col": 6,
+      "end_col": 19,
+      "end_lnum": 9,
+      "lnum": 9
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 1,
+    "end_lnum": 13,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 11,
+    "name": "\"my test\"",
+    "selection_range": {
+      "col": 5,
+      "end_col": 14,
+      "end_lnum": 11,
+      "lnum": 11
+    }
+  }
+]

--- a/tests/treesitter/zig_test.zig
+++ b/tests/treesitter/zig_test.zig
@@ -1,0 +1,13 @@
+fn myFunc() bool {
+    return true;
+}
+
+const MyStruct = struct {
+    is_true: bool,
+};
+
+const MyTaggedUnion = union(enum) { choice1, choice2 };
+
+test "my test" {
+    myFunc();
+}


### PR DESCRIPTION
This is very basic level support but it's enough for me personally to get value out of this plugin while doing zig development.

I tried to have it differentiate between methods and functions but it would end up dropping structs which contain methods. 