### PR TITLE
fix(julia): treesitter queries changed upstream

### DIFF
--- a/queries/julia/aerial.scm
+++ b/queries/julia/aerial.scm
@@ -18,19 +18,35 @@
   (#set! "kind" "Function")
   ) @symbol
 
-; TODO: Unsure how to translate this
-; (short_function_definition
-;   name: (identifier) @name
-;   (#set! "kind" "Function")
-;   ) @symbol
-;
-; TODO: Unsure how to translate this
-; (short_function_definition
-;   name: (field_expression
-;           value: (_)
-;           (identifier)) @name
-;   (#set! "kind" "Function")
-;   ) @symbol
+(assignment
+  (where_expression
+    (call_expression
+      .
+      (identifier) @name))
+  (#set! "kind" "Function")
+  ) @symbol
+
+(assignment
+  (where_expression
+    (call_expression
+      ((field_expression) @name)))
+  (#set! "kind" "Function")
+  ) @symbol
+
+(assignment
+  .
+  (call_expression
+    .
+    (identifier) @name)
+  (#set! "kind" "Function")
+  ) @symbol
+
+(assignment
+  .
+  (call_expression
+    ((field_expression) @name))
+  (#set! "kind" "Function")
+  ) @symbol
 
 (abstract_definition
   name: (identifier) @name

--- a/queries/julia/aerial.scm
+++ b/queries/julia/aerial.scm
@@ -14,9 +14,7 @@
 (function_definition
   (signature
     (call_expression
-      ( field_expression
-        value: (_)
-        (identifier) @name)))
+      ((field_expression) @name)))
   (#set! "kind" "Function")
   ) @symbol
 

--- a/queries/julia/aerial.scm
+++ b/queries/julia/aerial.scm
@@ -5,46 +5,20 @@
 
 (function_definition
   (signature
-    (call_expression
-      .
-      (identifier) @name))
-  (#set! "kind" "Function")
-  ) @symbol
-
-(function_definition
-  (signature
-    (call_expression
-      ((field_expression) @name)))
-  (#set! "kind" "Function")
-  ) @symbol
-
-(assignment
-  (where_expression
-    (call_expression
-      .
-      (identifier) @name))
-  (#set! "kind" "Function")
-  ) @symbol
-
-(assignment
-  (where_expression
-    (call_expression
-      ((field_expression) @name)))
+    ((call_expression) @name))
   (#set! "kind" "Function")
   ) @symbol
 
 (assignment
   .
-  (call_expression
-    .
-    (identifier) @name)
+  (where_expression
+    ((call_expression) @name))
   (#set! "kind" "Function")
   ) @symbol
 
 (assignment
   .
-  (call_expression
-    ((field_expression) @name))
+  ((call_expression) @name)
   (#set! "kind" "Function")
   ) @symbol
 
@@ -66,8 +40,6 @@
 
 (macro_definition
   (signature
-    (call_expression
-      .
-      (identifier) @name))
+    ((call_expression) @name))
   (#set! "kind" "Function")
   ) @symbol

--- a/queries/julia/aerial.scm
+++ b/queries/julia/aerial.scm
@@ -4,28 +4,35 @@
   ) @symbol
 
 (function_definition
-  name: (identifier) @name
+  (signature
+    (call_expression
+      .
+      (identifier) @name))
   (#set! "kind" "Function")
   ) @symbol
 
 (function_definition
-  name: (field_expression
-          value: (_)
-          (identifier)) @name
+  (signature
+    (call_expression
+      ( field_expression
+        value: (_)
+        (identifier) @name)))
   (#set! "kind" "Function")
   ) @symbol
 
-(short_function_definition
-  name: (identifier) @name
-  (#set! "kind" "Function")
-  ) @symbol
-
-(short_function_definition
-  name: (field_expression
-          value: (_)
-          (identifier)) @name
-  (#set! "kind" "Function")
-  ) @symbol
+; TODO: Unsure how to translate this
+; (short_function_definition
+;   name: (identifier) @name
+;   (#set! "kind" "Function")
+;   ) @symbol
+;
+; TODO: Unsure how to translate this
+; (short_function_definition
+;   name: (field_expression
+;           value: (_)
+;           (identifier)) @name
+;   (#set! "kind" "Function")
+;   ) @symbol
 
 (abstract_definition
   name: (identifier) @name
@@ -44,6 +51,9 @@
   ) @symbol
 
 (macro_definition
-  name: (identifier) @name
+  (signature
+    (call_expression
+      .
+      (identifier) @name))
   (#set! "kind" "Function")
   ) @symbol

--- a/tests/symbols/julia_test.json
+++ b/tests/symbols/julia_test.json
@@ -23,10 +23,10 @@
         "kind": "Function",
         "level": 1,
         "lnum": 5,
-        "name": "func",
+        "name": "func()",
         "selection_range": {
           "col": 9,
-          "end_col": 13,
+          "end_col": 15,
           "end_lnum": 5,
           "lnum": 5
         }
@@ -38,10 +38,10 @@
         "kind": "Function",
         "level": 1,
         "lnum": 8,
-        "name": "myfunc",
+        "name": "myfunc()",
         "selection_range": {
           "col": 0,
-          "end_col": 6,
+          "end_col": 8,
           "end_lnum": 8,
           "lnum": 8
         }
@@ -70,10 +70,10 @@
             "kind": "Function",
             "level": 2,
             "lnum": 13,
-            "name": "MyStruct",
+            "name": "MyStruct()",
             "selection_range": {
               "col": 4,
-              "end_col": 12,
+              "end_col": 14,
               "end_lnum": 13,
               "lnum": 13
             }
@@ -85,10 +85,10 @@
             "kind": "Function",
             "level": 2,
             "lnum": 14,
-            "name": "method",
+            "name": "method()",
             "selection_range": {
               "col": 4,
-              "end_col": 10,
+              "end_col": 12,
               "end_lnum": 14,
               "lnum": 14
             }
@@ -115,10 +115,10 @@
         "kind": "Function",
         "level": 1,
         "lnum": 17,
-        "name": "mac",
+        "name": "mac(expr)",
         "selection_range": {
           "col": 6,
-          "end_col": 9,
+          "end_col": 15,
           "end_lnum": 17,
           "lnum": 17
         }
@@ -132,10 +132,10 @@
             "kind": "Function",
             "level": 2,
             "lnum": 21,
-            "name": "mod.myfunc",
+            "name": "mod.myfunc()",
             "selection_range": {
               "col": 4,
-              "end_col": 14,
+              "end_col": 16,
               "end_lnum": 21,
               "lnum": 21
             }
@@ -147,10 +147,10 @@
             "kind": "Function",
             "level": 2,
             "lnum": 22,
-            "name": "mod.myfuncb",
+            "name": "mod.myfuncb()",
             "selection_range": {
               "col": 13,
-              "end_col": 24,
+              "end_col": 26,
               "end_lnum": 22,
               "lnum": 22
             }


### PR DESCRIPTION
This fixes the Julia queries to handle the breaking changes upstream.

This also fixes the symbol names to match what the language server returns. With Julia and it's multiple dispatch system it's very important to have the entire function definition in the symbol name. so we return the entire call expression as the `@name`

Fixes #361 