### PR TITLE
feat: added a highlight group for the left-hand side of the Nav float…

### DIFF
--- a/lua/aerial/highlight.lua
+++ b/lua/aerial/highlight.lua
@@ -93,7 +93,6 @@ M.create_highlight_groups = function()
   -- The line that shows where your cursor(s) are
   link("AerialLine", "QuickFixLine")
   link("AerialLineNC", "AerialLine")
-  link("AerialNavParent", "AerialLine")
 
   -- Highlight groups for private and protected functions/fields/etc
   link("AerialPrivate", "Comment")

--- a/lua/aerial/highlight.lua
+++ b/lua/aerial/highlight.lua
@@ -93,6 +93,7 @@ M.create_highlight_groups = function()
   -- The line that shows where your cursor(s) are
   link("AerialLine", "QuickFixLine")
   link("AerialLineNC", "AerialLine")
+  link("AerialNavParent", "AerialLine")
 
   -- Highlight groups for private and protected functions/fields/etc
   link("AerialPrivate", "Comment")
@@ -142,7 +143,6 @@ M.create_highlight_groups = function()
   link("AerialStringIcon", "Identifier")
   link("AerialStructIcon", "Type")
   link("AerialTypeParameterIcon", "Identifier")
-  link("AerialVariableIcon", "Identifier")
 end
 
 return M

--- a/lua/aerial/highlight.lua
+++ b/lua/aerial/highlight.lua
@@ -143,6 +143,7 @@ M.create_highlight_groups = function()
   link("AerialStringIcon", "Identifier")
   link("AerialStructIcon", "Type")
   link("AerialTypeParameterIcon", "Identifier")
+  link("AerialVariableIcon", "Identifier")
 end
 
 return M

--- a/lua/aerial/nav_view.lua
+++ b/lua/aerial/nav_view.lua
@@ -237,7 +237,8 @@ end
 function AerialNav:focus_symbol(symbol)
   local siblings, lnum = get_all_siblings(symbol)
   self.main.symbols = siblings
-  self.left.symbols = get_all_siblings(symbol.parent)
+  local parentlnum
+  self.left.symbols,parentlnum = get_all_siblings(symbol.parent)
   self.right.symbols = symbol.children or {}
 
   render_symbols(self.left,symbol.parent)
@@ -249,6 +250,9 @@ function AerialNav:focus_symbol(symbol)
     render_symbols(self.right)
   end
 
+  if vim.api.nvim_win_is_valid(self.left.winid) then
+    vim.api.nvim_win_set_cursor(self.left.winid, { parentlnum, 0 })
+  end
   if vim.api.nvim_win_is_valid(self.main.winid) then
     vim.api.nvim_win_set_cursor(self.main.winid, { lnum, 0 })
   end

--- a/lua/aerial/nav_view.lua
+++ b/lua/aerial/nav_view.lua
@@ -184,7 +184,7 @@ local function get_all_siblings(symbol)
 end
 
 ---@param panel aerial.NavPanel
-local function render_symbols(panel)
+local function render_symbols(panel,parent)
   local bufnr = panel.bufnr
   local lines = {}
   local highlights = {}
@@ -195,7 +195,12 @@ local function render_symbols(panel)
     table.insert(lines, text)
     local text_cols = vim.api.nvim_strwidth(text)
     table.insert(highlights, { "Aerial" .. item.kind .. "Icon", i - 1, 0, kind:len() })
-    table.insert(highlights, { "Aerial" .. item.kind, i - 1, kind:len(), -1 })
+    if item == parent then
+        table.insert(highlights, {"AerialNavParent", i - 1, kind:len(), -1})
+    else
+        table.insert(highlights,
+                     {"Aerial" .. item.kind, i - 1, kind:len(), -1})
+    end
     max_len = math.max(max_len, text_cols)
   end
 
@@ -235,7 +240,7 @@ function AerialNav:focus_symbol(symbol)
   self.left.symbols = get_all_siblings(symbol.parent)
   self.right.symbols = symbol.children or {}
 
-  render_symbols(self.left)
+  render_symbols(self.left,symbol.parent)
   render_symbols(self.main)
   if config.nav.preview and vim.tbl_isempty(self.right.symbols) then
     self:preview_symbol(self.right)

--- a/lua/aerial/nav_view.lua
+++ b/lua/aerial/nav_view.lua
@@ -184,7 +184,7 @@ local function get_all_siblings(symbol)
 end
 
 ---@param panel aerial.NavPanel
-local function render_symbols(panel,parent)
+local function render_symbols(panel, parent)
   local bufnr = panel.bufnr
   local lines = {}
   local highlights = {}
@@ -196,10 +196,9 @@ local function render_symbols(panel,parent)
     local text_cols = vim.api.nvim_strwidth(text)
     table.insert(highlights, { "Aerial" .. item.kind .. "Icon", i - 1, 0, kind:len() })
     if item == parent then
-        table.insert(highlights, {"AerialNavParent", i - 1, kind:len(), -1})
+      table.insert(highlights, { "AerialNavParent", i - 1, kind:len(), -1 })
     else
-        table.insert(highlights,
-                     {"Aerial" .. item.kind, i - 1, kind:len(), -1})
+      table.insert(highlights, { "Aerial" .. item.kind, i - 1, kind:len(), -1 })
     end
     max_len = math.max(max_len, text_cols)
   end
@@ -238,10 +237,10 @@ function AerialNav:focus_symbol(symbol)
   local siblings, lnum = get_all_siblings(symbol)
   self.main.symbols = siblings
   local parentlnum
-  self.left.symbols,parentlnum = get_all_siblings(symbol.parent)
+  self.left.symbols, parentlnum = get_all_siblings(symbol.parent)
   self.right.symbols = symbol.children or {}
 
-  render_symbols(self.left,symbol.parent)
+  render_symbols(self.left, symbol.parent)
   render_symbols(self.main)
   if config.nav.preview and vim.tbl_isempty(self.right.symbols) then
     self:preview_symbol(self.right)


### PR DESCRIPTION
… ui to indicate the parent of the current symbol

I like the Ranger-like UI, but the left-hand side does not indicate which node is the parent of the nodes in the middle pane.

I created a highlight group AerialNavParent and linked it to AerialLine

Here's a pic:
<img width="1398" alt="image" src="https://github.com/stevearc/aerial.nvim/assets/273927/02d9cff5-42ad-4f4f-846c-7278deed92da">

Note how `Mappings.n` is highlighted on the left