### PR TITLE
Remove deprecation warning in the nvim-0.5 branch

### DIFF
--- a/lua/aerial/window.lua
+++ b/lua/aerial/window.lua
@@ -250,12 +250,6 @@ M.maybe_open_automatic = function(bufnr)
 end
 
 M.open = function(focus, direction, opts)
-  if vim.fn.has("nvim-0.8") == 0 then
-    vim.notify_once(
-      "aerial is deprecated for Neovim <0.8. Please use the nvim-0.5 branch or upgrade Neovim",
-      vim.log.levels.WARN
-    )
-  end
   opts = vim.tbl_extend("keep", opts or {}, {
     winid = nil,
   })


### PR DESCRIPTION
The `nvim-0.5` branch should not have the deprecation warning for neovim versions smaller than `nvim-0.8`. This warning is for the `master` branch which requires newer neovim.