### PR TITLE
feat: add support for `mini.icons`

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ require("aerial").setup({
   -- icon when the tree is collapsed at that symbol, or "Collapsed" to specify a
   -- default collapsed icon. The default icon set is determined by the
   -- "nerd_font" option below.
-  -- If you have lspkind-nvim installed, it will be the default icon set.
+  -- If you have mini.icons or lspkind-nvim installed, it will be the default icon set.
   -- This can be a filetype map (see :help aerial-filetype-map)
   icons = {},
 
@@ -397,7 +397,7 @@ require("aerial").setup({
   link_tree_to_folds = true,
 
   -- Set default symbol icons to use patched font icons (see https://www.nerdfonts.com/)
-  -- "auto" will set it to true if nvim-web-devicons or lspkind-nvim is installed.
+  -- "auto" will set it to true if nvim-web-devicons, lspkind-nvim, or mini.icons is installed.
   nerd_font = "auto",
 
   -- Call this function when aerial attaches to a buffer.

--- a/doc/aerial.txt
+++ b/doc/aerial.txt
@@ -150,7 +150,7 @@ OPTIONS                                                           *aerial-option
       -- icon when the tree is collapsed at that symbol, or "Collapsed" to specify a
       -- default collapsed icon. The default icon set is determined by the
       -- "nerd_font" option below.
-      -- If you have lspkind-nvim installed, it will be the default icon set.
+      -- If you have mini.icons or lspkind-nvim installed, it will be the default icon set.
       -- This can be a filetype map (see :help aerial-filetype-map)
       icons = {},
 
@@ -203,7 +203,7 @@ OPTIONS                                                           *aerial-option
       link_tree_to_folds = true,
 
       -- Set default symbol icons to use patched font icons (see https://www.nerdfonts.com/)
-      -- "auto" will set it to true if nvim-web-devicons or lspkind-nvim is installed.
+      -- "auto" will set it to true if nvim-web-devicons, lspkind-nvim, or mini.icons is installed.
       nerd_font = "auto",
 
       -- Call this function when aerial attaches to a buffer.

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -86,7 +86,7 @@ describe("config", function()
 
   -- Icons
   it("reads icons from the default table", function()
-    config.setup({ nerd_font = true, use_lspkind = false })
+    config.setup({ nerd_font = true, use_icon_provider = false })
     assert.equals("󰊕 ", config.get_icon(0, "Function", false))
   end)
   it("reads icons from setup var", function()
@@ -95,7 +95,7 @@ describe("config", function()
       icons = {
         Function = "*",
       },
-      use_lspkind = false,
+      use_icon_provider = false,
     })
     assert.equals("*", config.get_icon(0, "Function", false))
     assert.equals("󰊕 ", config.get_icon(0, "Method", false))


### PR DESCRIPTION
This adds explicit support for [`mini.icons`](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-icons.md) for providing icons to oil. This generalizes the icon providing into a function that figures out which icon provider is available (preferring `mini.icons` over `lspkind`) and returning a common icon providing interface.

This also uses the `glyph` style in `mini.icons` to control the `nerd_font = "auto"` option since `mini.icons` has a built in style for not using nerd fonts and using plain text.

Lastly, this makes sure that the generalized icon provider function is lazily evaluated when it's necessary rather than on setup and caches the value so that it doesn't have to re-calculate the provider each time.