### PR TITLE
feat: Adds syntax highlighting in the telescope picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,8 @@ require("telescope").setup({
         json = true, -- You can set the option for specific filetypes
         yaml = true,
       },
+      -- Available modes: symbols, lines, both
+      show_columns = "both",
     },
   },
 })

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -64,6 +64,8 @@ local function aerial_picker(opts)
 
     local lang = vim.bo[bufnr].filetype
     local parser = ts_parsers.get_parser(bufnr, lang)
+    if not parser then return {} end
+
     local tree = parser:trees()[1] -- get already parsed cached tree
     local root = tree:root()
 

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -62,12 +62,11 @@ local function aerial_picker(opts)
     local ts_parsers = require("nvim-treesitter.parsers")
     local ts_query = require("nvim-treesitter.query")
 
-    local lang = vim.bo[bufnr].filetype
-    local parser = ts_parsers.get_parser(bufnr, lang)
+    local parser = ts_parsers.get_parser(bufnr)
     if not parser then return {} end
 
-    local tree = parser:trees()[1] -- get already parsed cached tree
-    local root = tree:root()
+    local lang = parser:lang()
+    local root = parser:trees()[1]:root() -- get root of already parsed cached tree
 
     local highlights = {}
     local query = ts_query.get_query(lang, 'highlights')


### PR DESCRIPTION
Adds syntax highlighting in the telescope picker. Issue https://github.com/stevearc/aerial.nvim/issues/384

1. syntax highlighting is shown in the telescope picker. By Treesitter, so all supported languages work.
2. adds `only_lines` picker config to show only code w/o symbols.
3. fixes several minor bugs where override configs were not applied correctly.

Some results:
<img width="825" alt="image" src="https://github.com/stevearc/aerial.nvim/assets/20628911/7d414829-c1f7-41a7-aa94-70325bce1bb3">

<img width="1094" alt="image" src="https://github.com/stevearc/aerial.nvim/assets/20628911/8cca6b0d-f6c7-43ee-bda2-c21d4467dd7d">

<img width="894" alt="image" src="https://github.com/stevearc/aerial.nvim/assets/20628911/c2ead98f-58a2-4e2e-b5fc-414bb68c2acf">

with `only_lines=true`

<img width="853" alt="image" src="https://github.com/stevearc/aerial.nvim/assets/20628911/0f7a74d6-e91e-490a-813f-97b45d48376b">


Other notes:
- `only_lines` - tried to name it in existing naming syntax, no any preferences, up to you
- this PR doesn't add syntax highlighting everywhere, which is a bigger task
- this PR doesn't solve all config issues, just some patches. Basically, IMO, all telescope configs need to be refactored to correctly pick: 1) aerial defaults 2) telescope defaults 3) plugin opitions 4) cmd options. This is a different task as well.
