### PR TITLE
Allow nesting symbol to be used with telescope and fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,9 @@ require("telescope").setup({
         json = true, -- You can set the option for specific filetypes
         yaml = true,
       },
+      -- Symbol for nesting, set to false for <root>.<parent>.<symbol>
+      -- Otherwise, can be a string like "├─"
+      nesting_symbol = false,
       -- Available modes: symbols, lines, both
       show_columns = "both",
     },

--- a/README.md
+++ b/README.md
@@ -601,15 +601,14 @@ The extension can be customized with the following options:
 require("telescope").setup({
   extensions = {
     aerial = {
-      -- Display symbols as <root>.<parent>.<symbol>
-      show_nesting = {
-        ["_"] = false, -- This key will be the default
-        json = true, -- You can set the option for specific filetypes
-        yaml = true,
-      },
-      -- Symbol for nesting, set to false for <root>.<parent>.<symbol>
-      -- Otherwise, can be a string like " >"
-      nesting_symbol = false,
+      -- How to format the symbols
+      format_symbol = function(symbol_path, filetype)
+        if filetype == "json" or filetype == "yaml" then
+          return table.concat(symbol_path, ".")
+        else
+          return symbol_path[#symbol_path]
+        end
+      end,
       -- Available modes: symbols, lines, both
       show_columns = "both",
     },

--- a/README.md
+++ b/README.md
@@ -610,6 +610,10 @@ require("telescope").setup({
       -- Symbol for nesting, set to false for <root>.<parent>.<symbol>
       -- Otherwise, can be a string like "├─"
       nesting_symbol = false,
+      -- If `nesting_symbol` uses non utf-8 characters, highlighting may break
+      -- set this value to an integer representing the number of characters instead
+      -- Setting to -1 means calculate automatically
+      nesting_symbol_length = -1,
       -- Available modes: symbols, lines, both
       show_columns = "both",
     },

--- a/README.md
+++ b/README.md
@@ -608,12 +608,8 @@ require("telescope").setup({
         yaml = true,
       },
       -- Symbol for nesting, set to false for <root>.<parent>.<symbol>
-      -- Otherwise, can be a string like "├─"
+      -- Otherwise, can be a string like " >"
       nesting_symbol = false,
-      -- If `nesting_symbol` uses non utf-8 characters, highlighting may break
-      -- set this value to an integer representing the number of characters instead
-      -- Setting to -1 means calculate automatically
-      nesting_symbol_length = -1,
       -- Available modes: symbols, lines, both
       show_columns = "both",
     },

--- a/README.md
+++ b/README.md
@@ -595,12 +595,6 @@ option).
 
 You can activate the picker with `:Telescope aerial` or `:lua require("telescope").extensions.aerial.aerial()`
 
-If you want the command to autocomplete, you can load the extension first:
-
-```lua
-require("telescope").load_extension("aerial")
-```
-
 The extension can be customized with the following options:
 
 ```lua
@@ -621,6 +615,12 @@ require("telescope").setup({
     },
   },
 })
+```
+
+If you want the command to autocomplete, you can load the extension first (this line must come after the setup section from above):
+
+```lua
+require("telescope").load_extension("aerial")
 ```
 
 ### fzf

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -13,6 +13,7 @@ local ext_config = {
     yaml = true,
   },
   nesting_symbol = false, -- false or string
+  nesting_symbol_length = -1, -- -1 for calculate from `nesting_symbol`
 }
 
 local function aerial_picker(opts)
@@ -44,10 +45,9 @@ local function aerial_picker(opts)
     ext_config.show_nesting[filetype] or ext_config.show_nesting["_"]
   )
   local nesting_symbol = ext_config.nesting_symbol
-  local nesting_symbol_length = 0
-  if nesting_symbol then
-    -- need to handle multibyte characters
-    nesting_symbol_length = vim.fn.strwidth(nesting_symbol)
+  local nesting_symbol_length = ext_config.nesting_symbol_length
+  if nesting_symbol_length == -1 then
+    nesting_symbol_length = #nesting_symbol
   end
 
   local backend = backends.get()

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -47,7 +47,7 @@ local function aerial_picker(opts)
   local nesting_symbol_length = 0
   if nesting_symbol then
     -- need to handle multibyte characters
-    _, nesting_symbol_length = string.gsub(nesting_symbol, "[^\128-\193]", "")
+    nesting_symbol_length = vim.fn.strwidth(nesting_symbol)
   end
 
   local backend = backends.get()

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -136,12 +136,7 @@ local function aerial_picker(opts)
       table.insert(columns, vim.trim(text))
 
       local leading_spaces = text:match("^%s*")
-      local offset = (
-          layout[1].width
-          + layout[2].width
-          - #leading_spaces
-          + #icon
-      )
+      local offset = (layout[1].width + layout[2].width - #leading_spaces + #icon)
       if #entry.name > layout[2].width then
         offset = offset + 2 -- '...' symbol
       end

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -143,7 +143,7 @@ local function aerial_picker(opts)
   end
 
   local function make_entry(item)
-    local name = item.name
+    local name
     if opts.get_entry_text ~= nil then
       name = opts.get_entry_text(item)
     else

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -27,7 +27,9 @@ local function aerial_picker(opts)
   local bufnr = vim.api.nvim_get_current_buf()
   local filename = vim.api.nvim_buf_get_name(0)
   local filetype = vim.bo[bufnr].filetype
-  local show_nesting = ext_config.show_nesting[filetype] or ext_config.show_nesting["_"]
+  local show_nesting = (
+    ext_config.show_nesting[filetype] or ext_config.show_nesting["_"]
+  )
   local nesting_symbol = ext_config.nesting_symbol
 
   local show_columns = opts.show_columns or conf.show_columns

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -27,6 +27,7 @@ local function aerial_picker(opts)
   local bufnr = vim.api.nvim_get_current_buf()
   local filename = vim.api.nvim_buf_get_name(0)
   local filetype = vim.bo[bufnr].filetype
+  local show_nesting = ext_config.show_nesting[filetype]
 
   local show_columns = opts.show_columns or conf.show_columns
   local show_lines = opts.show_lines or conf.show_lines -- show_lines is deprecated
@@ -40,11 +41,10 @@ local function aerial_picker(opts)
     end
   end
 
-  local show_nesting = (
-    ext_config.show_nesting[filetype] or ext_config.show_nesting["_"]
-  )
+  if show_nesting == nil then
+    show_nesting = ext_config.show_nesting["_"]
+  end
   local nesting_symbol = ext_config.nesting_symbol
-
   local backend = backends.get()
   if not backend then
     backends.log_support_err()

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -46,6 +46,7 @@ local function aerial_picker(opts)
   end
   local nesting_symbol = ext_config.nesting_symbol
   local backend = backends.get()
+
   if not backend then
     backends.log_support_err()
     return

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -13,7 +13,6 @@ local ext_config = {
     yaml = true,
   },
   nesting_symbol = false, -- false or string
-  nesting_symbol_length = -1, -- -1 for calculate from `nesting_symbol`
 }
 
 local function aerial_picker(opts)
@@ -45,10 +44,6 @@ local function aerial_picker(opts)
     ext_config.show_nesting[filetype] or ext_config.show_nesting["_"]
   )
   local nesting_symbol = ext_config.nesting_symbol
-  local nesting_symbol_length = ext_config.nesting_symbol_length
-  if nesting_symbol_length == -1 then
-    nesting_symbol_length = #nesting_symbol
-  end
 
   local backend = backends.get()
   if not backend then
@@ -118,7 +113,6 @@ local function aerial_picker(opts)
   end
 
   local function make_display(entry)
-    local depth = entry.depth
     local item = entry.value
     local row = item.lnum - 1
 
@@ -146,7 +140,6 @@ local function aerial_picker(opts)
           + layout[2].width
           - #leading_spaces
           + #icon
-          + depth * nesting_symbol_length
       )
       if #entry.name > layout[2].width then
         offset = offset + 2 -- '...' symbol
@@ -159,14 +152,12 @@ local function aerial_picker(opts)
 
   local function make_entry(item)
     local name = item.name
-    local depth = 0
     if opts.get_entry_text ~= nil then
       name = opts.get_entry_text(item)
     else
       if show_nesting then
         local cur = item.parent
         while cur do
-          depth = depth + 1
           if nesting_symbol then
             name = string.format("%s%s", nesting_symbol, name)
           else
@@ -182,7 +173,6 @@ local function aerial_picker(opts)
       value = item,
       display = make_display,
       name = name,
-      depth = depth,
       ordinal = name .. " " .. string.lower(item.kind),
       lnum = lnum,
       col = col + 1,

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -12,6 +12,7 @@ local ext_config = {
     json = true,
     yaml = true,
   },
+  nesting_symbol = false, -- false or string
 }
 
 local function aerial_picker(opts)
@@ -26,7 +27,8 @@ local function aerial_picker(opts)
   local bufnr = vim.api.nvim_get_current_buf()
   local filename = vim.api.nvim_buf_get_name(0)
   local filetype = vim.bo[bufnr].filetype
-  local show_nesting = ext_config.show_nesting[filetype]
+  local show_nesting = ext_config.show_nesting[filetype] or ext_config.show_nesting["_"]
+  local nesting_symbol = ext_config.nesting_symbol
 
   local show_columns = opts.show_columns or conf.show_columns
   local show_lines = opts.show_lines or conf.show_lines -- show_lines is deprecated
@@ -40,11 +42,7 @@ local function aerial_picker(opts)
     end
   end
 
-  if show_nesting == nil then
-    show_nesting = ext_config.show_nesting["_"]
-  end
   local backend = backends.get()
-
   if not backend then
     backends.log_support_err()
     return
@@ -152,7 +150,11 @@ local function aerial_picker(opts)
       if show_nesting then
         local cur = item.parent
         while cur do
-          name = string.format("%s.%s", cur.name, name)
+          if nesting_symbol then
+            name = string.format("%s%s", nesting_symbol, name)
+          else
+            name = string.format("%s.%s", cur.name, name)
+          end
           cur = cur.parent
         end
       end

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -7,12 +7,13 @@ local telescope = require("telescope")
 local ext_config = {
   -- show_lines = true, -- deprecated in favor of show_columns
   show_columns = "both", -- { "symbols", "lines", "both" }
-  show_nesting = {
-    ["_"] = false,
-    json = true,
-    yaml = true,
-  },
-  nesting_symbol = false, -- false or string
+  format_symbol = function(symbol_path, filetype)
+    if filetype == "json" or filetype == "yaml" then
+      return table.concat(symbol_path, ".")
+    else
+      return symbol_path[#symbol_path]
+    end
+  end,
 }
 
 local function aerial_picker(opts)
@@ -27,7 +28,6 @@ local function aerial_picker(opts)
   local bufnr = vim.api.nvim_get_current_buf()
   local filename = vim.api.nvim_buf_get_name(0)
   local filetype = vim.bo[bufnr].filetype
-  local show_nesting = ext_config.show_nesting[filetype]
 
   local show_columns = opts.show_columns or conf.show_columns
   local show_lines = opts.show_lines or conf.show_lines -- show_lines is deprecated
@@ -41,10 +41,6 @@ local function aerial_picker(opts)
     end
   end
 
-  if show_nesting == nil then
-    show_nesting = ext_config.show_nesting["_"]
-  end
-  local nesting_symbol = ext_config.nesting_symbol
   local backend = backends.get()
 
   if not backend then
@@ -136,7 +132,7 @@ local function aerial_picker(opts)
       table.insert(columns, vim.trim(text))
 
       local leading_spaces = text:match("^%s*")
-      local offset = (layout[1].width + layout[2].width - #leading_spaces + #icon)
+      local offset = layout[1].width + layout[2].width - #leading_spaces + #icon
       if #entry.name > layout[2].width then
         offset = offset + 2 -- '...' symbol
       end
@@ -151,17 +147,13 @@ local function aerial_picker(opts)
     if opts.get_entry_text ~= nil then
       name = opts.get_entry_text(item)
     else
-      if show_nesting then
-        local cur = item.parent
-        while cur do
-          if nesting_symbol then
-            name = string.format("%s%s", nesting_symbol, name)
-          else
-            name = string.format("%s.%s", cur.name, name)
-          end
-          cur = cur.parent
-        end
+      local symbol_path = {}
+      local cur = item
+      while cur do
+        table.insert(symbol_path, 1, cur.name)
+        cur = cur.parent
       end
+      name = ext_config.format_symbol(symbol_path, filetype)
     end
     local lnum = item.selection_range and item.selection_range.lnum or item.lnum
     local col = item.selection_range and item.selection_range.col or item.col
@@ -213,10 +205,29 @@ end
 return telescope.register_extension({
   setup = function(user_config)
     ext_config = vim.tbl_extend("force", ext_config, user_config or {})
-    if type(ext_config.show_nesting) ~= "table" then
-      ext_config.show_nesting = {
-        ["_"] = ext_config.show_nesting,
-      }
+
+    -- Backwards compatibility shim
+    if user_config.show_nesting and not user_config.format_symbol then
+      if type(ext_config.show_nesting) ~= "table" then
+        ext_config.show_nesting = {
+          ["_"] = ext_config.show_nesting,
+        }
+      end
+      ext_config.show_nesting = vim.tbl_deep_extend("keep", ext_config.show_nesting, {
+        json = true,
+        yaml = true,
+      })
+      user_config.format_symbol = function(symbol_path, filetype)
+        local show_nesting = ext_config.show_nesting[filetype]
+        if show_nesting == nil then
+          show_nesting = ext_config.show_nesting["_"]
+        end
+        if show_nesting then
+          return table.concat(symbol_path, ".")
+        else
+          return symbol_path[#symbol_path]
+        end
+      end
     end
   end,
   exports = {


### PR DESCRIPTION
This PR adds a nesting symbol in telescope, and also makes the readme a bit clearer when using with telescope to prevent #373.

### Examples of different nesting symbols
![image](https://github.com/user-attachments/assets/4f0e2c02-feb4-4abb-8be8-31f3c7934873)
![image](https://github.com/user-attachments/assets/fc13e441-abe2-4c53-b3e6-b1073eab004a)
![image](https://github.com/user-attachments/assets/d6bff69c-ad0b-49d8-ae39-a70a8d190bb1)


Closes #373 