### PR TITLE
feat(toml): treesitter support for TOML tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ In addition, you will need to have either Treesitter or a working LSP client. Yo
 - snakemake
 - solidity
 - teal
+- toml
 - tsx
 - typescript
 - usd

--- a/queries/toml/aerial.scm
+++ b/queries/toml/aerial.scm
@@ -1,0 +1,17 @@
+(table
+  [
+    (bare_key)
+    (dotted_key)
+    (quoted_key)
+  ] @name
+  (#set! "kind" "Class")
+) @symbol
+
+(table_array_element
+  [
+    (bare_key)
+    (dotted_key)
+    (quoted_key)
+  ] @name
+  (#set! "kind" "Enum")
+) @symbol

--- a/tests/symbols/toml_test.json
+++ b/tests/symbols/toml_test.json
@@ -1,0 +1,167 @@
+[
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 9,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 5,
+    "name": "owner",
+    "selection_range": {
+      "col": 1,
+      "end_col": 6,
+      "end_lnum": 5,
+      "lnum": 5
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 15,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 9,
+    "name": "database",
+    "selection_range": {
+      "col": 1,
+      "end_col": 9,
+      "end_lnum": 9,
+      "lnum": 9
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 17,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 15,
+    "name": "servers",
+    "selection_range": {
+      "col": 1,
+      "end_col": 8,
+      "end_lnum": 15,
+      "lnum": 15
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 21,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 17,
+    "name": "servers.alpha",
+    "selection_range": {
+      "col": 1,
+      "end_col": 14,
+      "end_lnum": 17,
+      "lnum": 17
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 26,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 21,
+    "name": "servers.beta",
+    "selection_range": {
+      "col": 1,
+      "end_col": 13,
+      "end_lnum": 21,
+      "lnum": 21
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 29,
+    "kind": "Enum",
+    "level": 0,
+    "lnum": 26,
+    "name": "fruits",
+    "selection_range": {
+      "col": 2,
+      "end_col": 8,
+      "end_lnum": 26,
+      "lnum": 26
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 33,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 29,
+    "name": "fruits.physical",
+    "selection_range": {
+      "col": 1,
+      "end_col": 16,
+      "end_lnum": 29,
+      "lnum": 29
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 36,
+    "kind": "Enum",
+    "level": 0,
+    "lnum": 33,
+    "name": "fruits.varieties",
+    "selection_range": {
+      "col": 2,
+      "end_col": 18,
+      "end_lnum": 33,
+      "lnum": 33
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 40,
+    "kind": "Enum",
+    "level": 0,
+    "lnum": 36,
+    "name": "fruits.varieties",
+    "selection_range": {
+      "col": 2,
+      "end_col": 18,
+      "end_lnum": 36,
+      "lnum": 36
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 43,
+    "kind": "Enum",
+    "level": 0,
+    "lnum": 40,
+    "name": "fruits",
+    "selection_range": {
+      "col": 2,
+      "end_col": 8,
+      "end_lnum": 40,
+      "lnum": 40
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 45,
+    "kind": "Enum",
+    "level": 0,
+    "lnum": 43,
+    "name": "fruits.varieties",
+    "selection_range": {
+      "col": 2,
+      "end_col": 18,
+      "end_lnum": 43,
+      "lnum": 43
+    }
+  }
+]

--- a/tests/treesitter/toml_test.toml
+++ b/tests/treesitter/toml_test.toml
@@ -1,0 +1,44 @@
+# This is a TOML document
+
+title = "TOML Example"
+
+[owner]
+name = "Tom Preston-Werner"
+dob = 1979-05-27T07:32:00-08:00
+
+[database]
+enabled = true
+ports = [ 8000, 8001, 8002 ]
+data = [ ["delta", "phi"], [3.14] ]
+temp_targets = { cpu = 79.5, case = 72.0 }
+
+[servers]
+
+[servers.alpha]
+ip = "10.0.0.1"
+role = "frontend"
+
+[servers.beta]
+ip = "10.0.0.2"
+role = "backend"
+
+
+[[fruits]]
+name = "apple"
+
+[fruits.physical]  # subtable
+color = "red"
+shape = "round"
+
+[[fruits.varieties]]  # nested array of tables
+name = "red delicious"
+
+[[fruits.varieties]]
+name = "granny smith"
+
+
+[[fruits]]
+name = "banana"
+
+[[fruits.varieties]]
+name = "plantain"


### PR DESCRIPTION
I wrote some queries for TOML.
Captures tables as "Class" and arrays of tables as "Enum".

```toml
[foo]
[foo.bar]
[[baz]]
[[baz]]
[[neo."vim"]]
[[neo."vim"]]
```
```
C foo
C foo.bar
E baz
E baz
E neo."vim"
E neo."vim"
```

Unfortunately, `[foo.bar]` is not actually a child of `[foo]` in the AST.

```scheme
(document
  (table
    (bare_key)) ; foo
  (table
    (dotted_key ; foo.bar
      (bare_key) ; foo
      (bare_key))) ; bar
  (table_array_element
    (bare_key)) ; baz
  (table_array_element ; baz
    (bare_key))
  (table_array_element
    (dotted_key ; neo."vim"
      (bare_key) ; neo
      (quoted_key))) ; "vim"
  (table_array_element
    (dotted_key ; neo."vim"
      (bare_key)
      (quoted_key))))
```

As a result, they are displayed as separate top level tables `foo` and `foo.bar`.
Would it be possible to neatly nest `bar` under `foo` using more complex predicates?
I am still learning how to write queries.