### PR TITLE
Fix warning when closing buffers with the LSP backend in place

### DIFF
--- a/lua/aerial/backends/init.lua
+++ b/lua/aerial/backends/init.lua
@@ -95,6 +95,9 @@ local function attach(bufnr, backend, name)
   if not backend or not name or name == existing_backend_name then
     return false
   end
+  if not bufnr or bufnr == 0 then
+    bufnr = vim.api.nvim_get_current_buf()
+  end
   set_backend(bufnr, name)
   backend.attach(bufnr)
   if existing_backend_name then

--- a/lua/aerial/backends/init.lua
+++ b/lua/aerial/backends/init.lua
@@ -95,9 +95,6 @@ local function attach(bufnr, backend, name)
   if not backend or not name or name == existing_backend_name then
     return false
   end
-  if not bufnr or bufnr == 0 then
-    bufnr = vim.api.nvim_get_current_buf()
-  end
   set_backend(bufnr, name)
   backend.attach(bufnr)
   if existing_backend_name then

--- a/lua/aerial/backends/lsp/init.lua
+++ b/lua/aerial/backends/lsp/init.lua
@@ -39,10 +39,6 @@ M.fetch_symbols = function(bufnr)
   local params = { textDocument = vim.lsp.util.make_text_document_params(bufnr) }
   local client = lsp_util.get_client(bufnr)
   if not client then
-    vim.notify(
-      string.format("No LSP client found that supports symbols in buffer %d", bufnr),
-      vim.log.levels.WARN
-    )
     return
   end
   local request_success =


### PR DESCRIPTION
Fixes #393

# The Issue

Before closing a buffer all language servers are detached from it. This cause the `LspDetach` event to occur before the buffer is deleted and therefore is still valid. Part of the autocommand here when a language server detaches is it refreshes the symbols which is great when it is because a language server crashes or stopped by the user, but in the case of a buffer getting deleted is not the operation we really want to happen. It leads to a notification that no language servers are attached that support symbols. This is expected since the buffer has not been deleted yet (but will be immediately after)

# The Solution

It seems like this warning in `fetch_symbols` may not be necessary at all. There is a similar warning in the `is_supported` method of the LSP backend which I think covers the cases where this will really come up and affect the user. I spent a while trying to figure out the best way to circumvent the message, but because there is not way to know from the `LspDetach` event that the buffer is about to be deleted there's no real way to figure this out.

Let me know if you have any other ideas regarding this or another way to identify if a buffer is about to be deleted!

# Additional Information

I also noticed an extra check for `bufnr` elsewhere in the code when it is checked a few lines prior. I simply removed that as well as part of this. If you want me to remove that commit to focus the PR I totally can :)


Thanks so much for your amazing plugins and overall contributions to the Neovim community 😄 