### PR TITLE
fix(php): anonymous_function_creation_expression replaced with anonymous_function

### DIFF
--- a/queries/php/aerial.scm
+++ b/queries/php/aerial.scm
@@ -5,7 +5,7 @@
 (expression_statement
   (assignment_expression
     left: (variable_name) @name
-    right: (anonymous_function_creation_expression) @symbol)
+    right: (anonymous_function) @symbol)
   (#set! "kind" "Function")) @start
 
 (class_declaration


### PR DESCRIPTION
```
Error executing vim.schedule lua callback: /usr/local/share/nvim/runtime/lua/vim/treesitter/query.lua:252: Query error at 8:13. Invalid node type "anonymous_function_creation_expression":
    right: (anonymous_function_creation_expression) @symbol)
            ^

stack traceback:
        [C]: in function '_ts_parse_query'
        /usr/local/share/nvim/runtime/lua/vim/treesitter/query.lua:252: in function 'fn'
        /usr/local/share/nvim/runtime/lua/vim/func/_memoize.lua:58: in function 'fn'
        /usr/local/share/nvim/runtime/lua/vim/func/_memoize.lua:58: in function 'get'
        ...y/aerial.nvim/lua/aerial/backends/treesitter/helpers.lua:43: in function 'get_query'
        ...lazy/aerial.nvim/lua/aerial/backends/treesitter/init.lua:19: in function 'is_supported'
        ...share/nvim/lazy/aerial.nvim/lua/aerial/backends/init.lua:40: in function 'is_supported'
        ...share/nvim/lazy/aerial.nvim/lua/aerial/backends/init.lua:73: in function 'get_best_backend'
        ...share/nvim/lazy/aerial.nvim/lua/aerial/backends/init.lua:147: in function 'get'
        ...share/nvim/lazy/aerial.nvim/lua/aerial/backends/init.lua:251: in function 'attach'
        .../share/nvim/lazy/aerial.nvim/lua/aerial/autocommands.lua:88: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

This was updated recently in php treesitter
https://github.com/nvim-treesitter/nvim-treesitter/commit/ec8776ed9ef56ffe7a61e67b64d5d6b6aba2c631
https://github.com/tree-sitter/tree-sitter-php/commit/0d3959bbd404c91535c8f913586561094f41fe54

