### PR TITLE
feat(just): treesitter support for Just

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ In addition, you will need to have either Treesitter or a working LSP client. Yo
 - javascript
 - json
 - julia
+- just
 - latex
 - lua
 - make

--- a/queries/just/aerial.scm
+++ b/queries/just/aerial.scm
@@ -1,0 +1,4 @@
+(recipe
+  (recipe_header
+    name: (identifier) @name)
+  (#set! "kind" "Interface")) @symbol

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -5,6 +5,7 @@ vim.bo.swapfile = false
 vim.filetype.add({
   -- Neovim doesn't have built-in filetype detection for these filetypes
   extension = {
+    just = "just",
     norg = "norg",
     objdump = "objdump",
     usd = "usd",

--- a/tests/symbols/just_test.json
+++ b/tests/symbols/just_test.json
@@ -1,0 +1,47 @@
+[
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 4,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 1,
+    "name": "build",
+    "selection_range": {
+      "col": 0,
+      "end_col": 5,
+      "end_lnum": 1,
+      "lnum": 1
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 7,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 4,
+    "name": "test",
+    "selection_range": {
+      "col": 0,
+      "end_col": 4,
+      "end_lnum": 4,
+      "lnum": 4
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 9,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 7,
+    "name": "sloc",
+    "selection_range": {
+      "col": 0,
+      "end_col": 4,
+      "end_lnum": 7,
+      "lnum": 7
+    }
+  }
+]

--- a/tests/treesitter/just_test.just
+++ b/tests/treesitter/just_test.just
@@ -1,0 +1,8 @@
+build:
+    cc main.c foo.c bar.c -o main
+
+test: build
+    ./test
+
+sloc:
+    @echo "`wc -l *.c` lines of code"


### PR DESCRIPTION
This change adds treesitter query to support `just` filetype.

Ref: https://github.com/casey/just