### PR TITLE
feat(starlark): treesitter support for Starlark

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ In addition, you will need to have either Treesitter or a working LSP client. Yo
 - scala
 - snakemake
 - solidity
+- starlark
 - teal
 - toml
 - tsx

--- a/lua/aerial/backends/treesitter/extensions.lua
+++ b/lua/aerial/backends/treesitter/extensions.lua
@@ -340,6 +340,18 @@ M.rst = {
   end,
 }
 
+M.starlark = {
+  postprocess = function(bufnr, item, match)
+    if item.kind == "Function" then
+      local rule_kind = node_from_match(match, "rule_kind")
+      local rule_name = assert(node_from_match(match, "rule_name"))
+      local name_text = get_node_text(rule_name, bufnr) or "<parse error>"
+      local kind_text = get_node_text(rule_kind, bufnr) or "<parse error>"
+      item.name = string.format("%s > %s", name_text, kind_text)
+    end
+  end,
+}
+
 M.typescript = {
   ---@note Additionally processes the following captures:
   ---      `@method`, `@string`, and `@modifier` - replaces name with "@method[.@modifier] @string"

--- a/queries/starlark/aerial.scm
+++ b/queries/starlark/aerial.scm
@@ -1,0 +1,10 @@
+(expression_statement
+  (call
+    function: (identifier) @rule_kind
+    (#not-any-of? @rule_kind "load")
+    arguments: (argument_list
+      (keyword_argument
+        name: (identifier)
+        value: (string
+          (string_content) @rule_name))))
+  (#set! "kind" "Function")) @symbol

--- a/tests/symbols/starlark_test.json
+++ b/tests/symbols/starlark_test.json
@@ -1,0 +1,11 @@
+[
+  {
+    "col": 0,
+    "end_col": 1,
+    "end_lnum": 6,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 3,
+    "name": "hello > go_binary"
+  }
+]

--- a/tests/treesitter/starlark_test.bazel
+++ b/tests/treesitter/starlark_test.bazel
@@ -1,0 +1,6 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+go_binary(
+    name = "hello",
+    srcs = ["hello.go"],
+)


### PR DESCRIPTION
feat(starlark): treesitter support for Starlark

This is for generating symbol outline for Bazel BUILD files. 