### PR TITLE
feat: explicitly set all to false in iter_matches

### DIFF
--- a/lua/aerial/backends/treesitter/init.lua
+++ b/lua/aerial/backends/treesitter/init.lua
@@ -35,6 +35,7 @@ M.fetch_symbols_sync = function(bufnr)
   end
   local lang = parser:lang()
   local syntax_tree = parser:parse()[1]
+  local syntax_tree_node = syntax_tree:root()
   local query = helpers.get_query(lang)
   if not query or not syntax_tree then
     backends.set_symbols(
@@ -48,8 +49,15 @@ M.fetch_symbols_sync = function(bufnr)
   -- It is used to determine node parents for the tree structure.
   local stack = {}
   local ext = extensions[lang]
-  ---@diagnostic disable-next-line: missing-parameter
-  for _, matches, metadata in query:iter_matches(syntax_tree:root(), bufnr) do
+  for _, matches, metadata in
+    query:iter_matches(
+      syntax_tree_node,
+      bufnr,
+      syntax_tree_node:start(),
+      syntax_tree_node:end_(),
+      { all = false }
+    )
+  do
     ---@note mimic nvim-treesitter's query.iter_group_results return values:
     --       {
     --         kind = "Method",

--- a/lua/aerial/backends/treesitter/init.lua
+++ b/lua/aerial/backends/treesitter/init.lua
@@ -35,7 +35,6 @@ M.fetch_symbols_sync = function(bufnr)
   end
   local lang = parser:lang()
   local syntax_tree = parser:parse()[1]
-  local syntax_tree_node = syntax_tree:root()
   local query = helpers.get_query(lang)
   if not query or not syntax_tree then
     backends.set_symbols(
@@ -50,13 +49,7 @@ M.fetch_symbols_sync = function(bufnr)
   local stack = {}
   local ext = extensions[lang]
   for _, matches, metadata in
-    query:iter_matches(
-      syntax_tree_node,
-      bufnr,
-      syntax_tree_node:start(),
-      syntax_tree_node:end_(),
-      { all = false }
-    )
+    query:iter_matches(syntax_tree:root(), bufnr, nil, nil, { all = false })
   do
     ---@note mimic nvim-treesitter's query.iter_group_results return values:
     --       {

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -81,7 +81,7 @@ local function aerial_picker(opts)
     local highlights = {}
     local query = vim.treesitter.query.get(lang, "highlights")
     if query then
-      for _, captures, _ in query:iter_matches(root, bufnr, 0, -1) do
+      for _, captures, _ in query:iter_matches(root, bufnr, 0, -1, { all = false }) do
         for id, node in pairs(captures) do
           local start_row, start_col, _, end_col = node:range()
           highlights[start_row] = highlights[start_row] or {}


### PR DESCRIPTION
Due to neovim's breaking change in treesitter, in nightly build the option all is set to true by default.

Closes #406