### PR TITLE
fix telescope highlights regression from #386

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,10 @@ The extension can be customized with the following options:
 require("telescope").setup({
   extensions = {
     aerial = {
+      -- Set the width of the first two columns (the second
+      -- is relevant only when show_columns is set to 'both')
+      col1_width = 4,
+      col2_width = 30,
       -- How to format the symbols
       format_symbol = function(symbol_path, filetype)
         if filetype == "json" or filetype == "yaml" then

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -100,16 +100,10 @@ local function aerial_picker(opts)
     buf_highlights = collect_buf_highlights() -- collect buffer highlights only if needed
   end
 
-  local function highlights_for_row(row, offset, icon_hl, name_hl)
+  local function highlights_for_row(row, offset)
     offset = offset or 0
     local row_highlights = buf_highlights[row] or {}
     local highlights = {}
-    if icon_hl ~= nil then
-      highlights = {
-        { { 0, COL1_WIDTH }, icon_hl },
-        { { COL1_WIDTH + 1, COL1_WIDTH + COL2_WIDTH + 3 }, name_hl },
-      }
-    end
     for _, value in ipairs(row_highlights) do
       local start_col, end_col, hl_type = unpack(value)
       hl_type = hl_type:match("^[^.]+") -- strip subtypes after dot
@@ -145,7 +139,13 @@ local function aerial_picker(opts)
       if #entry.name > layout[2].width then
         offset = offset + 2 -- '...' symbol
       end
-      highlights = highlights_for_row(row, offset, icon_hl, name_hl)
+      local col1_len = COL1_WIDTH + icon:len() - vim.api.nvim_strwidth(icon)
+      local col2_len = COL2_WIDTH + entry.name:len() - vim.api.nvim_strwidth(entry.name)
+      highlights = {
+        { { 0, col1_len }, icon_hl },
+        { { col1_len + 1, col1_len + 1 + col2_len + 1 }, name_hl },
+      }
+      vim.list_extend(highlights, highlights_for_row(row, offset))
     end
 
     return displayer(columns), highlights

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -4,10 +4,9 @@ local finders = require("telescope.finders")
 local pickers = require("telescope.pickers")
 local telescope = require("telescope")
 
-local COL1_WIDTH = 4
-local COL2_WIDTH = 30
-
 local ext_config = {
+  col1_width = 4,
+  col2_width = 30,
   -- show_lines = true, -- deprecated in favor of show_columns
   show_columns = "both", -- { "symbols", "lines", "both" }
   format_symbol = function(symbol_path, filetype)
@@ -56,13 +55,13 @@ local function aerial_picker(opts)
   local layout
   if show_columns == "both" then
     layout = {
-      { width = COL1_WIDTH },
-      { width = COL2_WIDTH },
+      { width = ext_config.col1_width },
+      { width = ext_config.col2_width },
       { remaining = true },
     }
   else
     layout = {
-      { width = COL1_WIDTH },
+      { width = ext_config.col1_width },
       { remaining = true },
     }
   end
@@ -139,8 +138,8 @@ local function aerial_picker(opts)
       if #entry.name > layout[2].width then
         offset = offset + 2 -- '...' symbol
       end
-      local col1_len = COL1_WIDTH + icon:len() - vim.api.nvim_strwidth(icon)
-      local col2_len = COL2_WIDTH + entry.name:len() - vim.api.nvim_strwidth(entry.name)
+      local col1_len = ext_config.col1_width + icon:len() - vim.api.nvim_strwidth(icon)
+      local col2_len = ext_config.col2_width + entry.name:len() - vim.api.nvim_strwidth(entry.name)
       highlights = {
         { { 0, col1_len }, icon_hl },
         { { col1_len + 1, col1_len + 1 + col2_len + 1 }, name_hl },

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -4,6 +4,9 @@ local finders = require("telescope.finders")
 local pickers = require("telescope.pickers")
 local telescope = require("telescope")
 
+local COL1_WIDTH = 4
+local COL2_WIDTH = 30
+
 local ext_config = {
   -- show_lines = true, -- deprecated in favor of show_columns
   show_columns = "both", -- { "symbols", "lines", "both" }
@@ -53,13 +56,13 @@ local function aerial_picker(opts)
   local layout
   if show_columns == "both" then
     layout = {
-      { width = 4 },
-      { width = 30 },
+      { width = COL1_WIDTH },
+      { width = COL2_WIDTH },
       { remaining = true },
     }
   else
     layout = {
-      { width = 4 },
+      { width = COL1_WIDTH },
       { remaining = true },
     }
   end
@@ -97,10 +100,16 @@ local function aerial_picker(opts)
     buf_highlights = collect_buf_highlights() -- collect buffer highlights only if needed
   end
 
-  local function highlights_for_row(row, offset)
+  local function highlights_for_row(row, offset, icon_hl, name_hl)
     offset = offset or 0
     local row_highlights = buf_highlights[row] or {}
     local highlights = {}
+    if icon_hl ~= nil then
+      highlights = {
+        { { 0, COL1_WIDTH }, icon_hl },
+        { { COL1_WIDTH + 1, COL1_WIDTH + COL2_WIDTH + 3 }, name_hl },
+      }
+    end
     for _, value in ipairs(row_highlights) do
       local start_col, end_col, hl_type = unpack(value)
       hl_type = hl_type:match("^[^.]+") -- strip subtypes after dot
@@ -136,7 +145,7 @@ local function aerial_picker(opts)
       if #entry.name > layout[2].width then
         offset = offset + 2 -- '...' symbol
       end
-      highlights = highlights_for_row(row, offset)
+      highlights = highlights_for_row(row, offset, icon_hl, name_hl)
     end
 
     return displayer(columns), highlights


### PR DESCRIPTION
the highlighting for the symbol type and the symbol name were lost with that change.

the telescope picker can be configured to display both symbol type and name and the line from the file.

#386 added highlighting for the line in the second part of the picker. however, doing so, it clobbered highlighting for the symbol type and name, which I am using thanks to the configurable `get_highlight` function to color differently public and private symbols.

this change makes sure the highlights for the first two columns are not clobbered by the line preview.

note, i'm not 100% sure about the offsets. i think there may be unicode widths shenanigans going on. but after this commit it's much better for sure.