### PR TITLE
java: don't start methods at annotations

### DIFF
--- a/queries/java/aerial.scm
+++ b/queries/java/aerial.scm
@@ -3,7 +3,7 @@
   (#set! "kind" "Interface")) @symbol
 
 (method_declaration
-  name: (identifier) @name
+  name: (identifier) @name @start
   (#set! "kind" "Method")) @symbol
 
 (constructor_declaration

--- a/tests/symbols/java_test.json
+++ b/tests/symbols/java_test.json
@@ -2,8 +2,8 @@
   {
     "children": [
       {
-        "col": 2,
-        "end_col": 16,
+        "col": 7,
+        "end_col": 13,
         "end_lnum": 2,
         "kind": "Method",
         "level": 1,
@@ -34,8 +34,8 @@
   {
     "children": [
       {
-        "col": 2,
-        "end_col": 19,
+        "col": 7,
+        "end_col": 13,
         "end_lnum": 6,
         "kind": "Method",
         "level": 1,
@@ -49,54 +49,69 @@
         }
       },
       {
-        "col": 2,
-        "end_col": 22,
-        "end_lnum": 7,
-        "kind": "Field",
-        "level": 1,
-        "lnum": 7,
-        "name": "field_1",
-        "selection_range": {
-          "col": 14,
-          "end_col": 21,
-          "end_lnum": 7,
-          "lnum": 7
-        }
-      },
-      {
-        "col": 2,
-        "end_col": 24,
+        "col": 7,
+        "end_col": 13,
         "end_lnum": 8,
-        "kind": "Field",
+        "kind": "Method",
         "level": 1,
         "lnum": 8,
-        "name": "field_2",
+        "name": "meth_3",
         "selection_range": {
-          "col": 16,
-          "end_col": 23,
+          "col": 7,
+          "end_col": 13,
           "end_lnum": 8,
           "lnum": 8
         }
       },
       {
         "col": 2,
-        "end_col": 12,
+        "end_col": 22,
         "end_lnum": 9,
-        "kind": "Constructor",
+        "kind": "Field",
         "level": 1,
         "lnum": 9,
+        "name": "field_1",
+        "selection_range": {
+          "col": 14,
+          "end_col": 21,
+          "end_lnum": 9,
+          "lnum": 9
+        }
+      },
+      {
+        "col": 2,
+        "end_col": 24,
+        "end_lnum": 10,
+        "kind": "Field",
+        "level": 1,
+        "lnum": 10,
+        "name": "field_2",
+        "selection_range": {
+          "col": 16,
+          "end_col": 23,
+          "end_lnum": 10,
+          "lnum": 10
+        }
+      },
+      {
+        "col": 2,
+        "end_col": 12,
+        "end_lnum": 11,
+        "kind": "Constructor",
+        "level": 1,
+        "lnum": 11,
         "name": "Cl_1",
         "selection_range": {
           "col": 2,
           "end_col": 6,
-          "end_lnum": 9,
-          "lnum": 9
+          "end_lnum": 11,
+          "lnum": 11
         }
       }
     ],
     "col": 0,
     "end_col": 1,
-    "end_lnum": 10,
+    "end_lnum": 12,
     "kind": "Class",
     "level": 0,
     "lnum": 5,
@@ -111,16 +126,16 @@
   {
     "col": 0,
     "end_col": 13,
-    "end_lnum": 12,
+    "end_lnum": 14,
     "kind": "Enum",
     "level": 0,
-    "lnum": 12,
+    "lnum": 14,
     "name": "En_1",
     "selection_range": {
       "col": 5,
       "end_col": 9,
-      "end_lnum": 12,
-      "lnum": 12
+      "end_lnum": 14,
+      "lnum": 14
     }
   }
 ]

--- a/tests/treesitter/java_test.java
+++ b/tests/treesitter/java_test.java
@@ -4,6 +4,8 @@ interface Iface_1 {
 
 class Cl_1 {
   void meth_2() { }
+  @Annotation
+  void meth_3() {}
   private int field_1;
   public Object field_2;
   Cl_1() { }


### PR DESCRIPTION
in the java tree-sitter hierarchy, annotations (`@Annotation`) before methods are nested within the `method_declaration`. In general they are indented on the line before the method itself (and sometimes there are many annotations, one per line, before the method).

The way aerial was capturing methods, in the telescope preview for instance, you'd see the annotation line instead of the method declaration line, and you were also taken to the "wrong" line.

![image](https://github.com/user-attachments/assets/bd03f558-bc71-44b2-90dc-59b4031d1851)
