### PR TITLE
feat(nim): add nim queries

### DIFF
--- a/queries/nim/aerial.scm
+++ b/queries/nim/aerial.scm
@@ -1,0 +1,135 @@
+; Enum
+(type_declaration
+  (type_symbol_declaration
+    name: (exported_symbol (identifier)) @name
+  )
+  (#set! "kind" "Enum")
+  (enum_declaration
+    (enum_field_declaration
+      (symbol_declaration
+        name: (identifier) @name
+      )
+      (#set! "kind" "EnumMember")
+    ) @symbol
+  )
+) @symbol
+
+(type_declaration
+  (type_symbol_declaration
+    name: (identifier) @name
+  )
+  (#set! "kind" "Enum")
+  (enum_declaration
+    (enum_field_declaration
+      (symbol_declaration
+        name: (identifier) @name
+        (#set! "kind" "EnumMember")
+      )
+    ) @symbol
+  )
+) @symbol
+
+; Object
+(type_declaration
+  (type_symbol_declaration
+    name: (exported_symbol
+      (identifier) @name
+    )
+  )
+  (object_declaration)
+  (#set! "kind" "Object")
+) @symbol
+
+; Object ref
+(type_declaration
+  (type_symbol_declaration
+    name: (exported_symbol
+      (identifier) @name
+    )
+  )
+  (ref_type
+    (object_declaration)
+  )
+  (#set! "kind" "Object")
+) @symbol
+
+; Template
+(template_declaration
+  name: (identifier) @name
+  (#set! "kind" "Function")
+) @symbol
+
+; Macro
+(macro_declaration
+  ; [1593, 0] - [1594, 13]
+  name: (identifier) @name
+  (#set! "kind" "Function")
+) @symbol
+
+; Proc
+(proc_declaration
+  name: (identifier) @name
+  (#set! "kind" "Function")
+) @symbol
+
+; Proc (exported)
+(proc_declaration
+  name: (exported_symbol (identifier) @name)
+  (#set! "kind" "Function")
+) @symbol
+
+; Func
+(func_declaration
+  name: (identifier) @name
+  (#set! "kind" "Function")
+) @symbol
+
+; Object fields
+(object_declaration
+  (field_declaration_list
+    (field_declaration
+      (symbol_declaration_list
+        (symbol_declaration
+          name: (exported_symbol
+            (identifier) @name
+          )
+          (#set! "kind" "Property")
+        ) @symbol
+      )
+    )
+  )
+)
+
+; Constant
+(const_section
+  (variable_declaration
+    (symbol_declaration_list
+      (symbol_declaration
+        name: (identifier) @name
+      )
+      (#set! "kind" "Constant")
+    ) @symbol
+  )
+)
+
+; Type
+(type_declaration
+  (type_symbol_declaration
+    name: (identifier) @name
+    (#set! "kind" "Class")
+  ) @symbol
+)
+
+; Top level variables
+(source_file
+  (var_section
+    (variable_declaration
+      (symbol_declaration_list
+        (symbol_declaration
+          name: (identifier) @name
+        )
+      )
+    )
+    (#set! "kind" "Variable")
+  ) @symbol
+)

--- a/tests/symbols/nim_test.json
+++ b/tests/symbols/nim_test.json
@@ -1,0 +1,246 @@
+[
+  {
+    "col": 0,
+    "end_col": 9,
+    "end_lnum": 2,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 1,
+    "name": "fn_1",
+    "selection_range": {
+      "col": 5,
+      "end_col": 9,
+      "end_lnum": 1,
+      "lnum": 1
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 9,
+    "end_lnum": 5,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 4,
+    "name": "fn_2",
+    "selection_range": {
+      "col": 5,
+      "end_col": 9,
+      "end_lnum": 4,
+      "lnum": 4
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 9,
+    "end_lnum": 8,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 7,
+    "name": "fn_3",
+    "selection_range": {
+      "col": 5,
+      "end_col": 9,
+      "end_lnum": 7,
+      "lnum": 7
+    }
+  },
+  {
+    "col": 5,
+    "end_col": 10,
+    "end_lnum": 10,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 10,
+    "name": "SHORT",
+    "selection_range": {
+      "col": 5,
+      "end_col": 10,
+      "end_lnum": 10,
+      "lnum": 10
+    }
+  },
+  {
+    "children": [
+      {
+        "col": 2,
+        "end_col": 10,
+        "end_lnum": 13,
+        "kind": "Property",
+        "level": 1,
+        "lnum": 13,
+        "name": "visited",
+        "selection_range": {
+          "col": 2,
+          "end_col": 9,
+          "end_lnum": 13,
+          "lnum": 13
+        }
+      },
+      {
+        "col": 2,
+        "end_col": 7,
+        "end_lnum": 14,
+        "kind": "Property",
+        "level": 1,
+        "lnum": 14,
+        "name": "data",
+        "selection_range": {
+          "col": 2,
+          "end_col": 6,
+          "end_lnum": 14,
+          "lnum": 14
+        }
+      }
+    ],
+    "col": 5,
+    "end_col": 18,
+    "end_lnum": 14,
+    "kind": "Object",
+    "level": 0,
+    "lnum": 12,
+    "name": "State",
+    "selection_range": {
+      "col": 5,
+      "end_col": 10,
+      "end_lnum": 12,
+      "lnum": 12
+    }
+  },
+  {
+    "children": [
+      {
+        "col": 2,
+        "end_col": 4,
+        "end_lnum": 18,
+        "kind": "Property",
+        "level": 1,
+        "lnum": 18,
+        "name": "X",
+        "selection_range": {
+          "col": 2,
+          "end_col": 3,
+          "end_lnum": 18,
+          "lnum": 18
+        }
+      },
+      {
+        "col": 2,
+        "end_col": 4,
+        "end_lnum": 19,
+        "kind": "Property",
+        "level": 1,
+        "lnum": 19,
+        "name": "Y",
+        "selection_range": {
+          "col": 2,
+          "end_col": 3,
+          "end_lnum": 19,
+          "lnum": 19
+        }
+      }
+    ],
+    "col": 5,
+    "end_col": 11,
+    "end_lnum": 19,
+    "kind": "Object",
+    "level": 0,
+    "lnum": 17,
+    "name": "COORD",
+    "selection_range": {
+      "col": 5,
+      "end_col": 10,
+      "end_lnum": 17,
+      "lnum": 17
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 26,
+    "end_lnum": 21,
+    "kind": "Variable",
+    "level": 0,
+    "lnum": 21,
+    "name": "top_level_var",
+    "selection_range": {
+      "col": 4,
+      "end_col": 17,
+      "end_lnum": 21,
+      "lnum": 21
+    }
+  },
+  {
+    "col": 2,
+    "end_col": 9,
+    "end_lnum": 24,
+    "kind": "Constant",
+    "level": 0,
+    "lnum": 24,
+    "name": "CONST_A",
+    "selection_range": {
+      "col": 2,
+      "end_col": 9,
+      "end_lnum": 24,
+      "lnum": 24
+    }
+  },
+  {
+    "col": 2,
+    "end_col": 9,
+    "end_lnum": 25,
+    "kind": "Constant",
+    "level": 0,
+    "lnum": 25,
+    "name": "CONST_B",
+    "selection_range": {
+      "col": 2,
+      "end_col": 9,
+      "end_lnum": 25,
+      "lnum": 25
+    }
+  },
+  {
+    "col": 5,
+    "end_col": 12,
+    "end_lnum": 27,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 27,
+    "name": "Options",
+    "selection_range": {
+      "col": 5,
+      "end_col": 12,
+      "end_lnum": 27,
+      "lnum": 27
+    }
+  },
+  {
+    "col": 2,
+    "end_col": 9,
+    "end_lnum": 28,
+    "kind": "EnumMember",
+    "level": 0,
+    "lnum": 28,
+    "name": "Option1",
+    "selection_range": {
+      "col": 2,
+      "end_col": 9,
+      "end_lnum": 28,
+      "lnum": 28
+    }
+  },
+  {
+    "col": 2,
+    "end_col": 9,
+    "end_lnum": 29,
+    "kind": "EnumMember",
+    "level": 0,
+    "lnum": 29,
+    "name": "Option2",
+    "selection_range": {
+      "col": 2,
+      "end_col": 9,
+      "end_lnum": 29,
+      "lnum": 29
+    }
+  }
+]

--- a/tests/treesitter/nim_test.nim
+++ b/tests/treesitter/nim_test.nim
@@ -1,0 +1,29 @@
+proc fn_1() =
+  discard
+
+proc fn_2*() =
+  discard
+
+func fn_3() =
+  discard
+
+type SHORT = int16
+
+type State* = object
+  visited*: bool
+  data*: ptr int32
+
+
+type COORD* {.bycopy.} = object
+  X*: SHORT
+  Y*: SHORT
+
+var top_level_var = "NONE"
+
+const
+  CONST_A = "A"
+  CONST_B = "B"
+
+type Options = enum
+  Option1
+  Option2


### PR DESCRIPTION
This is a draft I will try to pick up soon:

- [ ] Enum are conflicting with type aliasing (so on top of being miss tagged, their members aren't in the proper tree). I just figured that, first thing I'll look into when picking it up.
  <img width="450" alt="image" src="https://github.com/user-attachments/assets/2b040a09-be53-44a7-8008-02e2b695e7f5" />
  *Options is the enum here*

- [ ] confusing access to `declaration`. nim grammar use a common root for almost all declaration, unless I'm missing something this requires rather long queries like the ones I already have.
 
- [ ] test is missing some "selectors" I declared already (template,macro etc)