### PR TITLE
feat: add queries for R

### DIFF
--- a/queries/r/aerial.scm
+++ b/queries/r/aerial.scm
@@ -1,0 +1,5 @@
+(binary_operator
+    lhs: ((identifier) @name)
+    ["<-" "="]
+    rhs: (function_definition)
+    (#set! "kind" "Function")) @symbol

--- a/tests/symbols/r_test.json
+++ b/tests/symbols/r_test.json
@@ -1,0 +1,32 @@
+[
+  {
+    "col": 0,
+    "end_col": 1,
+    "end_lnum": 3,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 1,
+    "name": "my_function1",
+    "selection_range": {
+      "col": 0,
+      "end_col": 12,
+      "end_lnum": 1,
+      "lnum": 1
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 1,
+    "end_lnum": 7,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 5,
+    "name": "my_function2",
+    "selection_range": {
+      "col": 0,
+      "end_col": 12,
+      "end_lnum": 5,
+      "lnum": 5
+    }
+  }
+]

--- a/tests/treesitter/r_test.R
+++ b/tests/treesitter/r_test.R
@@ -1,0 +1,8 @@
+my_function1 <- function() {
+  NULL
+}
+
+my_function2 = function() {
+  NULL
+}
+


### PR DESCRIPTION
Adds support for R. Only adds one query for function definitions, but this is really all that's needed since R is a highly functional language.

I also added a test file `r_test.R`, but I wasn't able to get tests to run properly. Is there more to this than sourcing `tests/minimal_init.lua` and then using `:RunTests`?

Thanks! 