### PR TITLE
fix: elimante deprecated warings on nightly

### DIFF
--- a/lua/aerial/backends/lsp/init.lua
+++ b/lua/aerial/backends/lsp/init.lua
@@ -35,8 +35,13 @@ M.fetch_symbols = function(bufnr)
   if not client then
     return
   end
+  local request = vim.fn.has("nvim-0.11") == 1 and function(c, ...)
+    return c:request(...)
+  end or function(c, ...)
+    c.request(...)
+  end
   local request_success =
-    client.request("textDocument/documentSymbol", params, callbacks.symbol_callback, bufnr)
+    request(client, "textDocument/documentSymbol", params, callbacks.symbol_callback, bufnr)
   if not request_success then
     vim.notify("Error requesting document symbols", vim.log.levels.WARN)
   end
@@ -59,7 +64,13 @@ M.fetch_symbols_sync = function(bufnr, opts)
     return
   end
   local response
-  local request_success = client.request(
+  local request = vim.fn.has("nvim-0.11") == 1 and function(c, ...)
+    return c:request(...)
+  end or function(c, ...)
+    c.request(...)
+  end
+  local request_success = request(
+    client,
     "textDocument/documentSymbol",
     params,
     function(err, result)


### PR DESCRIPTION
```
- WARNING client.request is deprecated. Feature will be removed in Nvim
  0.13
  - ADVICE:
    - use client:request instead.
    - stack traceback: */aerial.nvim/lua/aerial/backends/lsp/init.lua:39
      */aerial.nvim/lua/aerial/backends/init.lua:124
      */aerial.nvim/lua/aerial/backends/init.lua:149
      */aerial.nvim/lua/aerial/window.lua:335
      */aerial.nvim/lua/aerial/window.lua:373
      */aerial.nvim/lua/aerial/init.lua:304
      */aerial.nvim/lua/aerial/command.lua:8
```
