### PR TITLE
Select snacks picker element based on cursor position

### DIFF
--- a/lua/aerial/snacks.lua
+++ b/lua/aerial/snacks.lua
@@ -60,6 +60,11 @@ M.pick_symbol = function(opts)
 
       return ret
     end,
+    on_show = function(picker)
+      local closest_or_exact_symbol = bufdata.positions[bufdata.last_win].exact_symbol or bufdata.positions[bufdata.last_win].closest_symbol
+      local currentIdx = closest_or_exact_symbol.idx
+      picker.list.cursor = currentIdx
+    end,
   }))
 end
 


### PR DESCRIPTION
When calling snacks picker, auto select the corresponding item, based on the cursor position on the buffer