### PR TITLE
fix: correctly set `last` property in `snack.picker` integration

### DIFF
--- a/lua/aerial/snacks.lua
+++ b/lua/aerial/snacks.lua
@@ -26,6 +26,8 @@ M.pick_symbol = function(opts)
   local bufdata = data.get_or_create(bufnr)
   ---@type snacks.picker.finder.Item[]
   local items = {}
+  ---@type table<snacks.picker.finder.Item, snacks.picker.finder.Item>
+  local last = {}
   for i, item in bufdata:iter({ skip_hidden = false }) do
     local snack_item = {
       idx = i,
@@ -36,7 +38,13 @@ M.pick_symbol = function(opts)
       end_pos = { item.end_lnum, item.end_col },
     }
     if item.parent then
-      snack_item.parent = items[item.parent.idx]
+      local parent = items[item.parent.idx]
+      snack_item.parent = parent
+      if last[parent] then
+        last[parent].last = nil
+      end
+      last[parent] = snack_item
+      snack_item.last = true
     end
     table.insert(items, snack_item)
   end


### PR DESCRIPTION
This modifies the `snacks.picker` integration to keep track of the last element of a parent and correctly sets the `last` field to `true`.

Before:

![2025-04-10_15:29:19_screenshot](https://github.com/user-attachments/assets/78cbf99a-f76a-4953-aa5f-d92fc19fb990)

After:

![2025-04-10_15:29:09_screenshot](https://github.com/user-attachments/assets/5a043dbf-ff81-4920-95ac-728d7440cd42)
