### PR TITLE
fix: prevent Aerial float window from closing on split (#456)

### DIFF
--- a/lua/aerial/navigation.lua
+++ b/lua/aerial/navigation.lua
@@ -233,7 +233,7 @@ M.select_symbol = function(item, winid, bufnr, opts)
     end
     local my_winid = vim.api.nvim_get_current_win()
     util.go_win_no_au(winid)
-    vim.cmd(split)
+    vim.cmd(string.format("noau %s", split))
     winid = vim.api.nvim_get_current_win()
     util.go_win_no_au(my_winid)
   end


### PR DESCRIPTION
# Fix issue 'bug: split vertical bug #456'

## Problem

Calling a split-based action (e.g. aerial.action.jump_vsplit()) from a floating Aerial window triggers an error.
This happens because floating windows in Aerial are automatically closed via an autocmd when the window loses focus.

In `aerial.navigation.select_symbol()`, the split command doesn't disable these autocmds, so the floating window gets closed during the split. When the code attempts to return to the now-closed window, it raises an error.

## Solution

Prefix the split command with `noautocmd` (`noau`) to prevent triggering the window-closing autocmd.
This aligns with the behavior of `aerial.util.go_win_no_au`, which also uses `noau` for safe window switching.
