### PR TITLE
fix(telescope): correct highlight offset computation (#414)

### DIFF
--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -128,26 +128,23 @@ local function aerial_picker(opts)
       { entry.name, name_hl },
     }
 
-    local highlights = {}
-    if show_columns == "both" then
-      local text = vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1] or ""
-      table.insert(columns, vim.trim(text))
-
-      local leading_spaces = text:match("^%s*")
-      local offset = layout[1].width + layout[2].width - #leading_spaces + #icon
-      if #entry.name > layout[2].width then
-        offset = offset + 2 -- '...' symbol
-      end
-      local col1_len = ext_config.col1_width + icon:len() - vim.api.nvim_strwidth(icon)
-      local col2_len = ext_config.col2_width + entry.name:len() - vim.api.nvim_strwidth(entry.name)
-      highlights = {
-        { { 0, col1_len }, icon_hl },
-        { { col1_len + 1, col1_len + 1 + col2_len + 1 }, name_hl },
-      }
-      vim.list_extend(highlights, highlights_for_row(row, offset))
+    if show_columns == "symbols" then
+      return displayer(columns)
     end
 
-    return displayer(columns), highlights
+    -- default: show_columns == "both"
+    local text = vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1] or ""
+    local trimmed_text = vim.trim(text)
+    table.insert(columns, trimmed_text)
+
+    local display_columns, highlights = displayer(columns)
+
+    local text_start = display_columns:find(trimmed_text, 1, true) or 1
+    local leading_spaces = text:match("^%s*") or ""
+    local offset = text_start - 1 - #leading_spaces
+    vim.list_extend(highlights, highlights_for_row(row, offset))
+
+    return display_columns, highlights
   end
 
   local function make_entry(item)


### PR DESCRIPTION
# Fix issue #414: highlights sometimes off by 1 in Telescope extension

This PR fixes incorrect offset computation for Tree-sitter highlights in the Telescope extension, which could cause them to appear shifted by one (or more) character.

## Root Cause

The issue tries to compute the highlight offset before calling `displayer()`. This approach is error-prone due to the presence of multibyte characters, single-byte characters, and potential line truncation, which makes it difficult to reliably calculate visual alignment.

## Solution

The fix changes the order of operations: it now calls `displayer()` first to get the final rendered string, then calculates the highlight offset by searching for the start position of the text to highlight within that string.

## Additional Fix

The issue also noted that no highlights were applied when `show_columns` was set to "symbols". This PR enables highlights in that mode as well, since icons are displayed (and usually highlighted).