### PR TITLE
feat: add fzf-lua symbol picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A code outline window for skimming and quick navigation
 - [Third-party integrations](#third-party-integrations)
   - [Snacks](#snacks)
   - [Telescope](#telescope)
+  - [fzf-lua](#fzf-lua)
   - [fzf](#fzf)
   - [Lualine](#lualine)
 - [Highlight](#highlight)
@@ -653,6 +654,23 @@ If you want the command to autocomplete, you can load the extension first (this 
 
 ```lua
 require("telescope").load_extension("aerial")
+```
+
+### fzf-lua
+
+If you have [fzf-lua](https://github.com/ibhagwan/fzf-lua/) installed, you can use the picker to find and jump to symbols.
+It supports multi-select and uses the default actions from the `files` picker (e.g. `<C-s>` to open a symbol in a split).
+
+```lua
+require("aerial").fzf_lua_picker()
+```
+
+You can pass in an options table that will get sent to `require('fzf-lua').fzf_exec` directly. Use this to customize the display.
+
+```lua
+require("aerial").fzf_lua_picker({
+  profile = 'ivy',
+})
 ```
 
 ### fzf

--- a/doc/aerial.txt
+++ b/doc/aerial.txt
@@ -539,6 +539,12 @@ snacks_picker({opts})                                       *aerial.snacks_picke
     Parameters:
       {opts} `nil|snacks.picker.Config`
 
+fzf_lua_picker({opts})                                     *aerial.fzf_lua_picker*
+    Open a document symbol picker using fzf-lua
+
+    Parameters:
+      {opts} `nil|table`
+
 get_location({exact}): aerial.SymbolView[]                   *aerial.get_location*
     Get a list representing the symbol path to the current location.
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -20,6 +20,7 @@
 - [next_up(count)](#next_upcount)
 - [prev_up(count)](#prev_upcount)
 - [snacks_picker(opts)](#snacks_pickeropts)
+- [fzf_lua_picker(opts)](#fzf_lua_pickeropts)
 - [get_location(exact)](#get_locationexact)
 - [tree_close_all(bufnr)](#tree_close_allbufnr)
 - [tree_open_all(bufnr)](#tree_open_allbufnr)
@@ -207,6 +208,15 @@ Open a document symbol picker using snacks.nvim
 | Param | Type                        | Desc |
 | ----- | --------------------------- | ---- |
 | opts  | `nil\|snacks.picker.Config` |      |
+
+## fzf_lua_picker(opts)
+
+`fzf_lua_picker(opts)` \
+Open a document symbol picker using fzf-lua
+
+| Param | Type                        | Desc |
+| ----- | --------------------------- | ---- |
+| opts  | `nil\|table`                |      |
 
 ## get_location(exact)
 

--- a/lua/aerial/fzf-lua.lua
+++ b/lua/aerial/fzf-lua.lua
@@ -1,0 +1,124 @@
+local backends = require("aerial.backends")
+local config = require("aerial.config")
+local data = require("aerial.data")
+local highlight = require("aerial.highlight")
+
+local fzf_lua = require("fzf-lua")
+local make_entry = require("fzf-lua.make_entry")
+local utils = require("fzf-lua.utils")
+
+local M = {}
+
+---@param opts? table
+M.pick_symbol = function(opts)
+  local bufnr = vim.api.nvim_get_current_buf()
+  local filename = vim.api.nvim_buf_get_name(bufnr)
+  local ok, backend = pcall(backends.get)
+
+  if not ok or not backend then
+    backends.log_support_err()
+    return
+  elseif not data.has_symbols(bufnr) then
+    backend.fetch_symbols_sync(bufnr, {})
+  end
+
+  if not data.has_symbols(bufnr) then
+    vim.notify("No symbols found in buffer", vim.log.levels.WARN)
+    return
+  end
+
+  local default_selection_index = 1
+  ---@type aerial.BufData
+  local bufdata = data.get_or_create(bufnr)
+  local position = bufdata.positions[bufdata.last_win]
+  ---@type table[]
+  local items = {}
+  ---@type table<table, table>
+  local last = {}
+  for i, symbol in bufdata:iter({ skip_hidden = false }) do
+    local item = {
+      idx = i,
+      filename = filename,
+      path = filename,
+      symbol = symbol,
+      lnum = symbol.lnum,
+      col = symbol.col,
+    }
+    if symbol.parent then
+      local parent = items[symbol.parent.idx]
+      item.parent = parent
+      if last[parent] then
+        last[parent].last = nil
+      end
+      last[parent] = item
+      item.last = true
+    end
+    if symbol == position.closest_symbol then
+      default_selection_index = (#items + 1)
+    end
+
+    table.insert(items, item)
+  end
+
+  -- generate formatted entries with icons for the tree structure
+  -- adapted from `Snacks.picker.format.tree()`
+  local entries = {}
+  for _, item in ipairs(items) do
+    local indent = {}
+    local node = item
+    while node and node.parent do
+      local icon
+      if node ~= item then
+        icon = node.last and "  " or "│ "
+      else
+        icon = node.last and "└╴" or "├╴"
+      end
+      table.insert(indent, 1, icon)
+      node = node.parent
+    end
+
+    item.text = string.format(
+      "%s%s%s%s%s",
+      utils.nbsp,
+      utils.ansi_from_hl("FzfLuaBufLineNr", table.concat(indent, "")),
+      utils.ansi_from_hl(
+        highlight.get_highlight(item.symbol, true, false),
+        config.get_icon(bufnr, item.symbol.kind)
+      ),
+      utils.nbsp,
+      item.symbol.name
+    )
+
+    table.insert(entries, make_entry.lcol(item, {}))
+  end
+
+  fzf_lua.fzf_exec(
+    entries,
+    vim.tbl_deep_extend("force", {
+      actions = fzf_lua.defaults.actions.files,
+      previewer = "builtin",
+      winopts = {
+        title = " Symbols ",
+      },
+      fzf_opts = {
+        ["--multi"] = true,
+        ["--layout"] = "reverse-list",
+        ["--delimiter"] = string.format("[%s]", utils.nbsp),
+        ["--with-nth"] = "2..",
+      },
+      keymap = {
+        fzf = {
+          load = string.format("pos(%d)", default_selection_index),
+        },
+      },
+      _fmt = {
+        from = function(text)
+          -- replace invisible spaces so fzf-lua can correctly detect the file location
+          return text:gsub(utils.nbsp, " ")
+        end,
+      },
+    }, opts or {})
+  )
+end
+
+return M

--- a/lua/aerial/init.lua
+++ b/lua/aerial/init.lua
@@ -365,6 +365,13 @@ M.snacks_picker = function(opts)
   require("aerial.snacks").pick_symbol(opts)
 end
 
+---Open a document symbol picker using fzf-lua
+---@param opts? table
+M.fzf_lua_picker = function(opts)
+  M.sync_load()
+  require("aerial.fzf-lua").pick_symbol(opts)
+end
+
 ---@class aerial.SymbolView : aerial.SymbolBase
 ---@field icon string
 


### PR DESCRIPTION
### Description

This adds a picker for https://github.com/ibhagwan/fzf-lua/

It supports multi-select and uses the default actions from the `files` picker (e.g. `<C-s>` to open a symbol in a split).

Adapted from the snacks picker.

### Screenshot

![image](https://github.com/user-attachments/assets/fd7de3a2-7e6c-4e22-8256-8501729d9ac5)
