### PR TITLE
feat(haskell): add treesitter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ In addition, you will need to have either Treesitter or a working LSP client. Yo
 - go
 - groovy
 - hcl
+- haskell
 - help
 - html
 - ini

--- a/lua/aerial/backends/treesitter/extensions.lua
+++ b/lua/aerial/backends/treesitter/extensions.lua
@@ -245,6 +245,18 @@ M.rust = {
   end,
 }
 
+M.haskell = {
+  postprocess = function(bufnr, item, match)
+    if item.kind == "Class" then
+      local class_node = node_from_match(match, "class")
+      local type = assert(node_from_match(match, "haskell_type"))
+      local name = get_node_text(type, bufnr) or "<parse error>"
+      local class = get_node_text(class_node, bufnr) or "<parse error>"
+      item.name = string.format("%s %s", class, name)
+    end
+  end,
+}
+
 M.ruby = {
   ---@note Additionally processes the following captures:
   ---      `@method`, `@receiver`, `@separator` - extends the name to "@method @reciever[@separator]@name", with @separator defaulting to "."

--- a/queries/haskell/aerial.scm
+++ b/queries/haskell/aerial.scm
@@ -1,0 +1,49 @@
+(declarations
+  (function
+    name: (variable) @name
+    (#set! "kind" "Function")) @symbol @start)
+
+(declarations
+  (bind
+    name: (variable) @name
+    (#set! "kind" "Function")) @symbol @start)
+
+(data_type
+  name: (name) @name
+  (#set! "kind" "Struct")) @symbol @start
+
+(newtype
+  name: (name) @name
+  (#set! "kind" "Struct")) @start @symbol
+
+(type_synomym
+  name: (name) @name
+  (#set! "kind" "Struct")) @start @symbol
+
+(declarations
+  (instance
+    name: (name) @class
+    patterns: _ @haskell_type
+    (#set! "kind" "Class")) @start @symbol)
+
+(instance
+  name: (name) @name
+
+  declarations: (instance_declarations
+    declaration: [
+      (function
+        name: (variable) @name)
+      (bind
+        name: (variable) @name)
+    ]
+    (#set! "kind" "Method")) @start @symbol)
+
+(class
+  name: (name) @name
+  (#set! "kind" "Interface")) @start @symbol
+
+(class
+  declarations: (class_declarations
+    declaration: (signature
+      name: (variable) @name)
+    (#set! "kind" "Method")) @start @symbol)

--- a/queries/haskell/aerial.scm
+++ b/queries/haskell/aerial.scm
@@ -16,7 +16,7 @@
   name: (name) @name
   (#set! "kind" "Struct")) @start @symbol
 
-(type_synomym
+(type_synonym
   name: (name) @name
   (#set! "kind" "Struct")) @start @symbol
 

--- a/tests/symbols/haskell_test.json
+++ b/tests/symbols/haskell_test.json
@@ -1,0 +1,135 @@
+[
+  {
+    "col": 0,
+    "end_col": 27,
+    "end_lnum": 3,
+    "kind": "Struct",
+    "level": 0,
+    "lnum": 3,
+    "name": "Data_1",
+    "selection_range": {
+      "col": 5,
+      "end_col": 11,
+      "end_lnum": 3,
+      "lnum": 3
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 42,
+    "end_lnum": 5,
+    "kind": "Struct",
+    "level": 0,
+    "lnum": 5,
+    "name": "NewType",
+    "selection_range": {
+      "col": 8,
+      "end_col": 15,
+      "end_lnum": 5,
+      "lnum": 5
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 30,
+    "end_lnum": 7,
+    "kind": "Struct",
+    "level": 0,
+    "lnum": 7,
+    "name": "TypeAlias_1",
+    "selection_range": {
+      "col": 5,
+      "end_col": 16,
+      "end_lnum": 7,
+      "lnum": 7
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 11,
+    "end_lnum": 10,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 10,
+    "name": "func",
+    "selection_range": {
+      "col": 0,
+      "end_col": 4,
+      "end_lnum": 10,
+      "lnum": 10
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 11,
+    "end_lnum": 12,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 12,
+    "name": "func_2",
+    "selection_range": {
+      "col": 0,
+      "end_col": 6,
+      "end_lnum": 12,
+      "lnum": 12
+    }
+  },
+  {
+    "children": [
+      {
+        "col": 2,
+        "end_col": 21,
+        "end_lnum": 15,
+        "kind": "Method",
+        "level": 1,
+        "lnum": 15,
+        "name": "classFn",
+        "selection_range": {
+          "col": 2,
+          "end_col": 9,
+          "end_lnum": 15,
+          "lnum": 15
+        }
+      }
+    ],
+    "col": 0,
+    "end_col": 21,
+    "end_lnum": 15,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 14,
+    "name": "MyClass",
+    "selection_range": {
+      "col": 6,
+      "end_col": 13,
+      "end_lnum": 14,
+      "lnum": 14
+    }
+  },
+  {
+    "children": [
+      {
+        "col": 2,
+        "end_col": 14,
+        "end_lnum": 18,
+        "kind": "Method",
+        "level": 1,
+        "lnum": 18,
+        "name": "classFn",
+        "selection_range": {
+          "col": 2,
+          "end_col": 9,
+          "end_lnum": 18,
+          "lnum": 18
+        }
+      }
+    ],
+    "col": 0,
+    "end_col": 14,
+    "end_lnum": 18,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 17,
+    "name": "MyClass Data_1"
+  }
+]

--- a/tests/treesitter/haskell_test.hs
+++ b/tests/treesitter/haskell_test.hs
@@ -1,0 +1,18 @@
+module HaskellTest where
+
+data Data_1 = Foo | Bar Int
+
+newtype NewType = NewType {newType :: Int}
+
+type TypeAlias_1 = (Int, Bool)
+
+func :: Int -> ()
+func x = ()
+
+func_2 = id
+
+class MyClass where
+  classFn :: () -> ()
+
+instance MyClass Data_1 where
+  classFn = id


### PR DESCRIPTION
Add haskell treesitter support. Would love to use `@trait` and `@rust_type` thing but I don't
really have time to look into that

TODO

- [x] skip non-top-level functions
- [x] idk what @symbol and @start really means I just tagged whatever
