### PR TITLE
fix: the lualine component become empty after calling :edit.

### DIFF
--- a/lua/aerial/autocommands.lua
+++ b/lua/aerial/autocommands.lua
@@ -77,7 +77,7 @@ local function update_aerial_windows()
   end
 end
 
-M.on_enter_buffer = util.throttle(function()
+M.on_enter_buffer = util.throttle(function(bufnr)
   local backends = require("aerial.backends")
   local config = require("aerial.config")
   local fold = require("aerial.fold")
@@ -85,7 +85,7 @@ M.on_enter_buffer = util.throttle(function()
   if util.is_ignored_win() then
     return
   end
-  backends.attach()
+  backends.attach(bufnr, true)
 
   local mybuf = vim.api.nvim_get_current_buf()
 

--- a/lua/aerial/backends/init.lua
+++ b/lua/aerial/backends/init.lua
@@ -92,7 +92,11 @@ local function attach(bufnr, backend, name)
     bufnr = vim.api.nvim_get_current_buf()
   end
   local existing_backend_name = M.get_attached_backend(bufnr)
-  if not backend or not name or name == existing_backend_name then
+  if not backend or not name then
+    return false
+  end
+  if name == existing_backend_name then
+    backend.fetch_symbols(bufnr)
     return false
   end
   if not bufnr or bufnr == 0 then

--- a/lua/aerial/init.lua
+++ b/lua/aerial/init.lua
@@ -163,9 +163,9 @@ local function create_autocmds()
     desc = "Aerial update windows and attach backends",
     pattern = "*",
     group = group,
-    callback = function()
+    callback = function(args)
       do_setup()
-      require("aerial.autocommands").on_enter_buffer()
+      require("aerial.autocommands").on_enter_buffer(args.buf)
     end,
   })
   vim.api.nvim_create_autocmd("LspAttach", {


### PR DESCRIPTION
Reason: `:edit` will trigger autocmd BufUnload and then data.delete_buf(bufnr). So the data has no symbols.

The content of lualine comes from get_status_normal() and get_status_dense() which formating symbols. But get_location return empty,

```
  if not data.has_symbols(0) then
    return {}
  end
```

So we need to fetch symbols on BufEnter.