### PR TITLE
feat: treesitter queries for css, ini, terraform, vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ In addition, you will need to have either Treesitter or a working LSP client. Yo
 - c
 - c_sharp
 - cpp
+- css
 - dart
 - djot
 - elixir
@@ -151,6 +152,7 @@ In addition, you will need to have either Treesitter or a working LSP client. Yo
 - groovy
 - help
 - html
+- ini
 - java
 - javascript
 - json
@@ -176,12 +178,14 @@ In addition, you will need to have either Treesitter or a working LSP client. Yo
 - starlark
 - swift
 - teal
+- terraform
 - toml
 - tsx
 - typescript
 - usd
 - vim
 - vimdoc
+- vue
 - xml
 - yaml
 - zig

--- a/queries/css/aerial.scm
+++ b/queries/css/aerial.scm
@@ -1,0 +1,5 @@
+(rule_set
+  (selectors
+    (_) @name @symbol)
+  (block) @start
+  (#set! "kind" "Class"))

--- a/queries/ini/aerial.scm
+++ b/queries/ini/aerial.scm
@@ -1,0 +1,4 @@
+(section
+  (section_name
+    (text) @name)
+  (#set! "kind" "Interface")) @symbol

--- a/queries/terraform/aerial.scm
+++ b/queries/terraform/aerial.scm
@@ -1,0 +1,5 @@
+; blocks
+(block
+  (string_lit
+    (template_literal) @name @symbol)
+  (#set! "kind" "Class"))

--- a/queries/vue/aerial.scm
+++ b/queries/vue/aerial.scm
@@ -1,0 +1,1 @@
+; inherits: html

--- a/tests/symbols/css_test.json
+++ b/tests/symbols/css_test.json
@@ -1,0 +1,467 @@
+[
+  {
+    "col": 9,
+    "end_col": 1,
+    "end_lnum": 12,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 8,
+    "name": "div.body",
+    "selection_range": {
+      "col": 0,
+      "end_col": 8,
+      "end_lnum": 8,
+      "lnum": 8
+    }
+  },
+  {
+    "col": 36,
+    "end_col": 1,
+    "end_lnum": 22,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 16,
+    "name": "div.header",
+    "selection_range": {
+      "col": 0,
+      "end_col": 10,
+      "end_lnum": 16,
+      "lnum": 16
+    }
+  },
+  {
+    "col": 36,
+    "end_col": 1,
+    "end_lnum": 22,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 16,
+    "name": "div.content",
+    "selection_range": {
+      "col": 12,
+      "end_col": 23,
+      "end_lnum": 16,
+      "lnum": 16
+    }
+  },
+  {
+    "col": 36,
+    "end_col": 1,
+    "end_lnum": 22,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 16,
+    "name": "div.footer",
+    "selection_range": {
+      "col": 25,
+      "end_col": 35,
+      "end_lnum": 16,
+      "lnum": 16
+    }
+  },
+  {
+    "col": 19,
+    "end_col": 1,
+    "end_lnum": 28,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 24,
+    "name": "div.header-wrapper",
+    "selection_range": {
+      "col": 0,
+      "end_col": 18,
+      "end_lnum": 24,
+      "lnum": 24
+    }
+  },
+  {
+    "col": 11,
+    "end_col": 1,
+    "end_lnum": 35,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 32,
+    "name": "div.header",
+    "selection_range": {
+      "col": 0,
+      "end_col": 10,
+      "end_lnum": 32,
+      "lnum": 32
+    }
+  },
+  {
+    "col": 14,
+    "end_col": 1,
+    "end_lnum": 40,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 37,
+    "name": "div.header h1",
+    "selection_range": {
+      "col": 0,
+      "end_col": 13,
+      "end_lnum": 37,
+      "lnum": 37
+    }
+  },
+  {
+    "col": 16,
+    "end_col": 1,
+    "end_lnum": 46,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 42,
+    "name": "div.header h1 a",
+    "selection_range": {
+      "col": 0,
+      "end_col": 15,
+      "end_lnum": 42,
+      "lnum": 42
+    }
+  },
+  {
+    "col": 23,
+    "end_col": 1,
+    "end_lnum": 53,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 48,
+    "name": "div.header div.right a",
+    "selection_range": {
+      "col": 0,
+      "end_col": 22,
+      "end_lnum": 48,
+      "lnum": 48
+    }
+  },
+  {
+    "col": 19,
+    "end_col": 1,
+    "end_lnum": 59,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 55,
+    "name": "div.header div.rel",
+    "selection_range": {
+      "col": 0,
+      "end_col": 18,
+      "end_lnum": 55,
+      "lnum": 55
+    }
+  },
+  {
+    "col": 13,
+    "end_col": 1,
+    "end_lnum": 70,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 63,
+    "name": "div.document",
+    "selection_range": {
+      "col": 0,
+      "end_col": 12,
+      "end_lnum": 63,
+      "lnum": 63
+    }
+  },
+  {
+    "col": 28,
+    "end_col": 1,
+    "end_lnum": 76,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 72,
+    "name": "div.document div.section h1",
+    "selection_range": {
+      "col": 0,
+      "end_col": 27,
+      "end_lnum": 72,
+      "lnum": 72
+    }
+  },
+  {
+    "col": 28,
+    "end_col": 1,
+    "end_lnum": 83,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 78,
+    "name": "div.document div.section dl",
+    "selection_range": {
+      "col": 0,
+      "end_col": 27,
+      "end_lnum": 78,
+      "lnum": 78
+    }
+  },
+  {
+    "col": 12,
+    "end_col": 1,
+    "end_lnum": 94,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 87,
+    "name": "div.sidebar",
+    "selection_range": {
+      "col": 0,
+      "end_col": 11,
+      "end_lnum": 87,
+      "lnum": 87
+    }
+  },
+  {
+    "col": 15,
+    "end_col": 1,
+    "end_lnum": 99,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 96,
+    "name": "div.sidebar ul",
+    "selection_range": {
+      "col": 0,
+      "end_col": 14,
+      "end_lnum": 96,
+      "lnum": 96
+    }
+  },
+  {
+    "col": 28,
+    "end_col": 1,
+    "end_lnum": 103,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 101,
+    "name": "div.sidebar li.toctree-l1 a",
+    "selection_range": {
+      "col": 0,
+      "end_col": 27,
+      "end_lnum": 101,
+      "lnum": 101
+    }
+  },
+  {
+    "col": 28,
+    "end_col": 1,
+    "end_lnum": 107,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 105,
+    "name": "div.sidebar li.toctree-l2 a",
+    "selection_range": {
+      "col": 0,
+      "end_col": 27,
+      "end_lnum": 105,
+      "lnum": 105
+    }
+  },
+  {
+    "col": 28,
+    "end_col": 1,
+    "end_lnum": 111,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 109,
+    "name": "div.sidebar li.toctree-l3 a",
+    "selection_range": {
+      "col": 0,
+      "end_col": 27,
+      "end_lnum": 109,
+      "lnum": 109
+    }
+  },
+  {
+    "col": 36,
+    "end_col": 1,
+    "end_lnum": 115,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 113,
+    "name": "div.sidebar li.toctree-l2.current a",
+    "selection_range": {
+      "col": 0,
+      "end_col": 35,
+      "end_lnum": 113,
+      "lnum": 113
+    }
+  },
+  {
+    "col": 36,
+    "end_col": 1,
+    "end_lnum": 119,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 117,
+    "name": "div.sidebar li.toctree-l3.current a",
+    "selection_range": {
+      "col": 0,
+      "end_col": 35,
+      "end_lnum": 117,
+      "lnum": 117
+    }
+  },
+  {
+    "col": 28,
+    "end_col": 1,
+    "end_lnum": 123,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 121,
+    "name": "div.sidebar li.toctree-l4 a",
+    "selection_range": {
+      "col": 0,
+      "end_col": 27,
+      "end_lnum": 121,
+      "lnum": 121
+    }
+  },
+  {
+    "col": 29,
+    "end_col": 1,
+    "end_lnum": 127,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 125,
+    "name": "div.sidebar input[type=text]",
+    "selection_range": {
+      "col": 0,
+      "end_col": 28,
+      "end_lnum": 125,
+      "lnum": 125
+    }
+  },
+  {
+    "col": 24,
+    "end_col": 1,
+    "end_lnum": 133,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 131,
+    "name": "dt:target",
+    "selection_range": {
+      "col": 0,
+      "end_col": 9,
+      "end_lnum": 131,
+      "lnum": 131
+    }
+  },
+  {
+    "col": 24,
+    "end_col": 1,
+    "end_lnum": 133,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 131,
+    "name": ".highlighted",
+    "selection_range": {
+      "col": 11,
+      "end_col": 23,
+      "end_lnum": 131,
+      "lnum": 131
+    }
+  },
+  {
+    "col": 4,
+    "end_col": 1,
+    "end_lnum": 140,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 137,
+    "name": "pre",
+    "selection_range": {
+      "col": 0,
+      "end_col": 3,
+      "end_lnum": 137,
+      "lnum": 137
+    }
+  },
+  {
+    "col": 15,
+    "end_col": 1,
+    "end_lnum": 147,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 142,
+    "name": "td.linenos pre",
+    "selection_range": {
+      "col": 0,
+      "end_col": 14,
+      "end_lnum": 142,
+      "lnum": 142
+    }
+  },
+  {
+    "col": 10,
+    "end_col": 1,
+    "end_lnum": 153,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 151,
+    "name": "ol.arabic",
+    "selection_range": {
+      "col": 0,
+      "end_col": 9,
+      "end_lnum": 151,
+      "lnum": 151
+    }
+  },
+  {
+    "col": 14,
+    "end_col": 1,
+    "end_lnum": 157,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 155,
+    "name": "ol.loweralpha",
+    "selection_range": {
+      "col": 0,
+      "end_col": 13,
+      "end_lnum": 155,
+      "lnum": 155
+    }
+  },
+  {
+    "col": 14,
+    "end_col": 1,
+    "end_lnum": 161,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 159,
+    "name": "ol.upperalpha",
+    "selection_range": {
+      "col": 0,
+      "end_col": 13,
+      "end_lnum": 159,
+      "lnum": 159
+    }
+  },
+  {
+    "col": 14,
+    "end_col": 1,
+    "end_lnum": 165,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 163,
+    "name": "ol.lowerroman",
+    "selection_range": {
+      "col": 0,
+      "end_col": 13,
+      "end_lnum": 163,
+      "lnum": 163
+    }
+  },
+  {
+    "col": 14,
+    "end_col": 1,
+    "end_lnum": 169,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 167,
+    "name": "ol.upperroman",
+    "selection_range": {
+      "col": 0,
+      "end_col": 13,
+      "end_lnum": 167,
+      "lnum": 167
+    }
+  }
+]

--- a/tests/symbols/ini_test.json
+++ b/tests/symbols/ini_test.json
@@ -1,0 +1,92 @@
+[
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 4,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 1,
+    "name": "core",
+    "selection_range": {
+      "col": 1,
+      "end_col": 5,
+      "end_lnum": 1,
+      "lnum": 1
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 7,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 5,
+    "name": "libinput",
+    "selection_range": {
+      "col": 1,
+      "end_col": 9,
+      "end_lnum": 5,
+      "lnum": 5
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 13,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 8,
+    "name": "shell",
+    "selection_range": {
+      "col": 1,
+      "end_col": 6,
+      "end_lnum": 8,
+      "lnum": 8
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 17,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 14,
+    "name": "keyboard",
+    "selection_range": {
+      "col": 1,
+      "end_col": 9,
+      "end_lnum": 14,
+      "lnum": 14
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 21,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 18,
+    "name": "launcher",
+    "selection_range": {
+      "col": 1,
+      "end_col": 9,
+      "end_lnum": 18,
+      "lnum": 18
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 25,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 22,
+    "name": "launcher",
+    "selection_range": {
+      "col": 1,
+      "end_col": 9,
+      "end_lnum": 22,
+      "lnum": 22
+    }
+  }
+]

--- a/tests/symbols/terraform_test.json
+++ b/tests/symbols/terraform_test.json
@@ -1,0 +1,77 @@
+[
+  {
+    "col": 10,
+    "end_col": 13,
+    "end_lnum": 1,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 1,
+    "name": "aws",
+    "selection_range": {
+      "col": 10,
+      "end_col": 13,
+      "end_lnum": 1,
+      "lnum": 1
+    }
+  },
+  {
+    "col": 10,
+    "end_col": 17,
+    "end_lnum": 5,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 5,
+    "name": "aws_vpc",
+    "selection_range": {
+      "col": 10,
+      "end_col": 17,
+      "end_lnum": 5,
+      "lnum": 5
+    }
+  },
+  {
+    "col": 20,
+    "end_col": 28,
+    "end_lnum": 5,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 5,
+    "name": "demo_vpc",
+    "selection_range": {
+      "col": 20,
+      "end_col": 28,
+      "end_lnum": 5,
+      "lnum": 5
+    }
+  },
+  {
+    "col": 10,
+    "end_col": 20,
+    "end_lnum": 13,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 13,
+    "name": "aws_subnet",
+    "selection_range": {
+      "col": 10,
+      "end_col": 20,
+      "end_lnum": 13,
+      "lnum": 13
+    }
+  },
+  {
+    "col": 23,
+    "end_col": 34,
+    "end_lnum": 13,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 13,
+    "name": "demo_subnet",
+    "selection_range": {
+      "col": 23,
+      "end_col": 34,
+      "end_lnum": 13,
+      "lnum": 13
+    }
+  }
+]

--- a/tests/symbols/vue_test.json
+++ b/tests/symbols/vue_test.json
@@ -1,0 +1,965 @@
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "col": 7,
+            "end_col": 34,
+            "end_lnum": 2,
+            "kind": "Field",
+            "level": 2,
+            "lnum": 2,
+            "name": "class",
+            "selection_range": {
+              "col": 7,
+              "end_col": 12,
+              "end_lnum": 2,
+              "lnum": 2
+            }
+          },
+          {
+            "children": [
+              {
+                "col": 9,
+                "end_col": 26,
+                "end_lnum": 3,
+                "kind": "Field",
+                "level": 3,
+                "lnum": 3,
+                "name": "class",
+                "selection_range": {
+                  "col": 9,
+                  "end_col": 14,
+                  "end_lnum": 3,
+                  "lnum": 3
+                }
+              },
+              {
+                "children": [
+                  {
+                    "col": 19,
+                    "end_col": 39,
+                    "end_lnum": 4,
+                    "kind": "Field",
+                    "level": 4,
+                    "lnum": 4,
+                    "name": "class",
+                    "selection_range": {
+                      "col": 19,
+                      "end_col": 24,
+                      "end_lnum": 4,
+                      "lnum": 4
+                    }
+                  }
+                ],
+                "col": 6,
+                "end_col": 20,
+                "end_lnum": 6,
+                "kind": "Struct",
+                "level": 3,
+                "lnum": 4,
+                "name": "router-link",
+                "selection_range": {
+                  "col": 7,
+                  "end_col": 18,
+                  "end_lnum": 4,
+                  "lnum": 4
+                }
+              },
+              {
+                "children": [
+                  {
+                    "col": 34,
+                    "end_col": 70,
+                    "end_lnum": 7,
+                    "kind": "Field",
+                    "level": 4,
+                    "lnum": 7,
+                    "name": "class",
+                    "selection_range": {
+                      "col": 34,
+                      "end_col": 39,
+                      "end_lnum": 7,
+                      "lnum": 7
+                    }
+                  },
+                  {
+                    "children": [
+                      {
+                        "col": 12,
+                        "end_col": 28,
+                        "end_lnum": 8,
+                        "kind": "Field",
+                        "level": 5,
+                        "lnum": 8,
+                        "name": "class",
+                        "selection_range": {
+                          "col": 12,
+                          "end_col": 17,
+                          "end_lnum": 8,
+                          "lnum": 8
+                        }
+                      },
+                      {
+                        "children": [
+                          {
+                            "col": 12,
+                            "end_col": 28,
+                            "end_lnum": 10,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 10,
+                            "name": "class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 17,
+                              "end_lnum": 10,
+                              "lnum": 10
+                            }
+                          },
+                          {
+                            "col": 12,
+                            "end_col": 33,
+                            "end_lnum": 11,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 11,
+                            "name": "active-class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 24,
+                              "end_lnum": 11,
+                              "lnum": 11
+                            }
+                          },
+                          {
+                            "col": 12,
+                            "end_col": 17,
+                            "end_lnum": 12,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 12,
+                            "name": "exact",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 17,
+                              "end_lnum": 12,
+                              "lnum": 12
+                            }
+                          }
+                        ],
+                        "col": 10,
+                        "end_col": 24,
+                        "end_lnum": 16,
+                        "kind": "Struct",
+                        "level": 5,
+                        "lnum": 9,
+                        "name": "router-link",
+                        "selection_range": {
+                          "col": 11,
+                          "end_col": 22,
+                          "end_lnum": 9,
+                          "lnum": 9
+                        }
+                      }
+                    ],
+                    "col": 8,
+                    "end_col": 13,
+                    "end_lnum": 17,
+                    "kind": "Struct",
+                    "level": 4,
+                    "lnum": 8,
+                    "name": "li",
+                    "selection_range": {
+                      "col": 9,
+                      "end_col": 11,
+                      "end_lnum": 8,
+                      "lnum": 8
+                    }
+                  },
+                  {
+                    "children": [
+                      {
+                        "col": 12,
+                        "end_col": 28,
+                        "end_lnum": 18,
+                        "kind": "Field",
+                        "level": 5,
+                        "lnum": 18,
+                        "name": "class",
+                        "selection_range": {
+                          "col": 12,
+                          "end_col": 17,
+                          "end_lnum": 18,
+                          "lnum": 18
+                        }
+                      },
+                      {
+                        "children": [
+                          {
+                            "col": 12,
+                            "end_col": 28,
+                            "end_lnum": 20,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 20,
+                            "name": "class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 17,
+                              "end_lnum": 20,
+                              "lnum": 20
+                            }
+                          },
+                          {
+                            "col": 12,
+                            "end_col": 33,
+                            "end_lnum": 21,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 21,
+                            "name": "active-class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 24,
+                              "end_lnum": 21,
+                              "lnum": 21
+                            }
+                          },
+                          {
+                            "col": 12,
+                            "end_col": 17,
+                            "end_lnum": 22,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 22,
+                            "name": "exact",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 17,
+                              "end_lnum": 22,
+                              "lnum": 22
+                            }
+                          },
+                          {
+                            "children": [
+                              {
+                                "col": 15,
+                                "end_col": 34,
+                                "end_lnum": 25,
+                                "kind": "Field",
+                                "level": 7,
+                                "lnum": 25,
+                                "name": "class",
+                                "selection_range": {
+                                  "col": 15,
+                                  "end_col": 20,
+                                  "end_lnum": 25,
+                                  "lnum": 25
+                                }
+                              }
+                            ],
+                            "col": 12,
+                            "end_col": 39,
+                            "end_lnum": 25,
+                            "kind": "Struct",
+                            "level": 6,
+                            "lnum": 25,
+                            "name": "i",
+                            "selection_range": {
+                              "col": 13,
+                              "end_col": 14,
+                              "end_lnum": 25,
+                              "lnum": 25
+                            }
+                          }
+                        ],
+                        "col": 10,
+                        "end_col": 24,
+                        "end_lnum": 26,
+                        "kind": "Struct",
+                        "level": 5,
+                        "lnum": 19,
+                        "name": "router-link",
+                        "selection_range": {
+                          "col": 11,
+                          "end_col": 22,
+                          "end_lnum": 19,
+                          "lnum": 19
+                        }
+                      }
+                    ],
+                    "col": 8,
+                    "end_col": 13,
+                    "end_lnum": 27,
+                    "kind": "Struct",
+                    "level": 4,
+                    "lnum": 18,
+                    "name": "li",
+                    "selection_range": {
+                      "col": 9,
+                      "end_col": 11,
+                      "end_lnum": 18,
+                      "lnum": 18
+                    }
+                  },
+                  {
+                    "children": [
+                      {
+                        "col": 12,
+                        "end_col": 28,
+                        "end_lnum": 28,
+                        "kind": "Field",
+                        "level": 5,
+                        "lnum": 28,
+                        "name": "class",
+                        "selection_range": {
+                          "col": 12,
+                          "end_col": 17,
+                          "end_lnum": 28,
+                          "lnum": 28
+                        }
+                      },
+                      {
+                        "children": [
+                          {
+                            "col": 12,
+                            "end_col": 28,
+                            "end_lnum": 30,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 30,
+                            "name": "class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 17,
+                              "end_lnum": 30,
+                              "lnum": 30
+                            }
+                          },
+                          {
+                            "col": 12,
+                            "end_col": 33,
+                            "end_lnum": 31,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 31,
+                            "name": "active-class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 24,
+                              "end_lnum": 31,
+                              "lnum": 31
+                            }
+                          },
+                          {
+                            "col": 12,
+                            "end_col": 17,
+                            "end_lnum": 32,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 32,
+                            "name": "exact",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 17,
+                              "end_lnum": 32,
+                              "lnum": 32
+                            }
+                          },
+                          {
+                            "children": [
+                              {
+                                "col": 15,
+                                "end_col": 34,
+                                "end_lnum": 35,
+                                "kind": "Field",
+                                "level": 7,
+                                "lnum": 35,
+                                "name": "class",
+                                "selection_range": {
+                                  "col": 15,
+                                  "end_col": 20,
+                                  "end_lnum": 35,
+                                  "lnum": 35
+                                }
+                              }
+                            ],
+                            "col": 12,
+                            "end_col": 39,
+                            "end_lnum": 35,
+                            "kind": "Struct",
+                            "level": 6,
+                            "lnum": 35,
+                            "name": "i",
+                            "selection_range": {
+                              "col": 13,
+                              "end_col": 14,
+                              "end_lnum": 35,
+                              "lnum": 35
+                            }
+                          }
+                        ],
+                        "col": 10,
+                        "end_col": 24,
+                        "end_lnum": 36,
+                        "kind": "Struct",
+                        "level": 5,
+                        "lnum": 29,
+                        "name": "router-link",
+                        "selection_range": {
+                          "col": 11,
+                          "end_col": 22,
+                          "end_lnum": 29,
+                          "lnum": 29
+                        }
+                      }
+                    ],
+                    "col": 8,
+                    "end_col": 13,
+                    "end_lnum": 37,
+                    "kind": "Struct",
+                    "level": 4,
+                    "lnum": 28,
+                    "name": "li",
+                    "selection_range": {
+                      "col": 9,
+                      "end_col": 11,
+                      "end_lnum": 28,
+                      "lnum": 28
+                    }
+                  }
+                ],
+                "col": 6,
+                "end_col": 11,
+                "end_lnum": 38,
+                "kind": "Struct",
+                "level": 3,
+                "lnum": 7,
+                "name": "ul",
+                "selection_range": {
+                  "col": 7,
+                  "end_col": 9,
+                  "end_lnum": 7,
+                  "lnum": 7
+                }
+              },
+              {
+                "children": [
+                  {
+                    "col": 17,
+                    "end_col": 53,
+                    "end_lnum": 39,
+                    "kind": "Field",
+                    "level": 4,
+                    "lnum": 39,
+                    "name": "class",
+                    "selection_range": {
+                      "col": 17,
+                      "end_col": 22,
+                      "end_lnum": 39,
+                      "lnum": 39
+                    }
+                  },
+                  {
+                    "children": [
+                      {
+                        "col": 12,
+                        "end_col": 28,
+                        "end_lnum": 40,
+                        "kind": "Field",
+                        "level": 5,
+                        "lnum": 40,
+                        "name": "class",
+                        "selection_range": {
+                          "col": 12,
+                          "end_col": 17,
+                          "end_lnum": 40,
+                          "lnum": 40
+                        }
+                      },
+                      {
+                        "children": [
+                          {
+                            "col": 12,
+                            "end_col": 28,
+                            "end_lnum": 42,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 42,
+                            "name": "class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 17,
+                              "end_lnum": 42,
+                              "lnum": 42
+                            }
+                          },
+                          {
+                            "col": 12,
+                            "end_col": 33,
+                            "end_lnum": 43,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 43,
+                            "name": "active-class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 24,
+                              "end_lnum": 43,
+                              "lnum": 43
+                            }
+                          },
+                          {
+                            "col": 12,
+                            "end_col": 17,
+                            "end_lnum": 44,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 44,
+                            "name": "exact",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 17,
+                              "end_lnum": 44,
+                              "lnum": 44
+                            }
+                          }
+                        ],
+                        "col": 10,
+                        "end_col": 24,
+                        "end_lnum": 48,
+                        "kind": "Struct",
+                        "level": 5,
+                        "lnum": 41,
+                        "name": "router-link",
+                        "selection_range": {
+                          "col": 11,
+                          "end_col": 22,
+                          "end_lnum": 41,
+                          "lnum": 41
+                        }
+                      }
+                    ],
+                    "col": 8,
+                    "end_col": 13,
+                    "end_lnum": 49,
+                    "kind": "Struct",
+                    "level": 4,
+                    "lnum": 40,
+                    "name": "li",
+                    "selection_range": {
+                      "col": 9,
+                      "end_col": 11,
+                      "end_lnum": 40,
+                      "lnum": 40
+                    }
+                  },
+                  {
+                    "children": [
+                      {
+                        "col": 12,
+                        "end_col": 28,
+                        "end_lnum": 50,
+                        "kind": "Field",
+                        "level": 5,
+                        "lnum": 50,
+                        "name": "class",
+                        "selection_range": {
+                          "col": 12,
+                          "end_col": 17,
+                          "end_lnum": 50,
+                          "lnum": 50
+                        }
+                      },
+                      {
+                        "children": [
+                          {
+                            "col": 12,
+                            "end_col": 28,
+                            "end_lnum": 52,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 52,
+                            "name": "class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 17,
+                              "end_lnum": 52,
+                              "lnum": 52
+                            }
+                          },
+                          {
+                            "col": 12,
+                            "end_col": 33,
+                            "end_lnum": 53,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 53,
+                            "name": "active-class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 24,
+                              "end_lnum": 53,
+                              "lnum": 53
+                            }
+                          },
+                          {
+                            "children": [
+                              {
+                                "col": 15,
+                                "end_col": 34,
+                                "end_lnum": 56,
+                                "kind": "Field",
+                                "level": 7,
+                                "lnum": 56,
+                                "name": "class",
+                                "selection_range": {
+                                  "col": 15,
+                                  "end_col": 20,
+                                  "end_lnum": 56,
+                                  "lnum": 56
+                                }
+                              }
+                            ],
+                            "col": 12,
+                            "end_col": 39,
+                            "end_lnum": 56,
+                            "kind": "Struct",
+                            "level": 6,
+                            "lnum": 56,
+                            "name": "i",
+                            "selection_range": {
+                              "col": 13,
+                              "end_col": 14,
+                              "end_lnum": 56,
+                              "lnum": 56
+                            }
+                          }
+                        ],
+                        "col": 10,
+                        "end_col": 24,
+                        "end_lnum": 57,
+                        "kind": "Struct",
+                        "level": 5,
+                        "lnum": 51,
+                        "name": "router-link",
+                        "selection_range": {
+                          "col": 11,
+                          "end_col": 22,
+                          "end_lnum": 51,
+                          "lnum": 51
+                        }
+                      }
+                    ],
+                    "col": 8,
+                    "end_col": 13,
+                    "end_lnum": 58,
+                    "kind": "Struct",
+                    "level": 4,
+                    "lnum": 50,
+                    "name": "li",
+                    "selection_range": {
+                      "col": 9,
+                      "end_col": 11,
+                      "end_lnum": 50,
+                      "lnum": 50
+                    }
+                  },
+                  {
+                    "children": [
+                      {
+                        "col": 12,
+                        "end_col": 28,
+                        "end_lnum": 59,
+                        "kind": "Field",
+                        "level": 5,
+                        "lnum": 59,
+                        "name": "class",
+                        "selection_range": {
+                          "col": 12,
+                          "end_col": 17,
+                          "end_lnum": 59,
+                          "lnum": 59
+                        }
+                      },
+                      {
+                        "children": [
+                          {
+                            "col": 12,
+                            "end_col": 28,
+                            "end_lnum": 61,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 61,
+                            "name": "class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 17,
+                              "end_lnum": 61,
+                              "lnum": 61
+                            }
+                          },
+                          {
+                            "col": 12,
+                            "end_col": 33,
+                            "end_lnum": 62,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 62,
+                            "name": "active-class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 24,
+                              "end_lnum": 62,
+                              "lnum": 62
+                            }
+                          },
+                          {
+                            "col": 12,
+                            "end_col": 17,
+                            "end_lnum": 63,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 63,
+                            "name": "exact",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 17,
+                              "end_lnum": 63,
+                              "lnum": 63
+                            }
+                          },
+                          {
+                            "children": [
+                              {
+                                "col": 15,
+                                "end_col": 33,
+                                "end_lnum": 66,
+                                "kind": "Field",
+                                "level": 7,
+                                "lnum": 66,
+                                "name": "class",
+                                "selection_range": {
+                                  "col": 15,
+                                  "end_col": 20,
+                                  "end_lnum": 66,
+                                  "lnum": 66
+                                }
+                              }
+                            ],
+                            "col": 12,
+                            "end_col": 38,
+                            "end_lnum": 66,
+                            "kind": "Struct",
+                            "level": 6,
+                            "lnum": 66,
+                            "name": "i",
+                            "selection_range": {
+                              "col": 13,
+                              "end_col": 14,
+                              "end_lnum": 66,
+                              "lnum": 66
+                            }
+                          }
+                        ],
+                        "col": 10,
+                        "end_col": 24,
+                        "end_lnum": 67,
+                        "kind": "Struct",
+                        "level": 5,
+                        "lnum": 60,
+                        "name": "router-link",
+                        "selection_range": {
+                          "col": 11,
+                          "end_col": 22,
+                          "end_lnum": 60,
+                          "lnum": 60
+                        }
+                      }
+                    ],
+                    "col": 8,
+                    "end_col": 13,
+                    "end_lnum": 68,
+                    "kind": "Struct",
+                    "level": 4,
+                    "lnum": 59,
+                    "name": "li",
+                    "selection_range": {
+                      "col": 9,
+                      "end_col": 11,
+                      "end_lnum": 59,
+                      "lnum": 59
+                    }
+                  },
+                  {
+                    "children": [
+                      {
+                        "col": 12,
+                        "end_col": 28,
+                        "end_lnum": 69,
+                        "kind": "Field",
+                        "level": 5,
+                        "lnum": 69,
+                        "name": "class",
+                        "selection_range": {
+                          "col": 12,
+                          "end_col": 17,
+                          "end_lnum": 69,
+                          "lnum": 69
+                        }
+                      },
+                      {
+                        "children": [
+                          {
+                            "col": 12,
+                            "end_col": 28,
+                            "end_lnum": 71,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 71,
+                            "name": "class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 17,
+                              "end_lnum": 71,
+                              "lnum": 71
+                            }
+                          },
+                          {
+                            "col": 12,
+                            "end_col": 33,
+                            "end_lnum": 72,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 72,
+                            "name": "active-class",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 24,
+                              "end_lnum": 72,
+                              "lnum": 72
+                            }
+                          },
+                          {
+                            "col": 12,
+                            "end_col": 17,
+                            "end_lnum": 73,
+                            "kind": "Field",
+                            "level": 6,
+                            "lnum": 73,
+                            "name": "exact",
+                            "selection_range": {
+                              "col": 12,
+                              "end_col": 17,
+                              "end_lnum": 73,
+                              "lnum": 73
+                            }
+                          }
+                        ],
+                        "col": 10,
+                        "end_col": 24,
+                        "end_lnum": 80,
+                        "kind": "Struct",
+                        "level": 5,
+                        "lnum": 70,
+                        "name": "router-link",
+                        "selection_range": {
+                          "col": 11,
+                          "end_col": 22,
+                          "end_lnum": 70,
+                          "lnum": 70
+                        }
+                      }
+                    ],
+                    "col": 8,
+                    "end_col": 13,
+                    "end_lnum": 81,
+                    "kind": "Struct",
+                    "level": 4,
+                    "lnum": 69,
+                    "name": "li",
+                    "selection_range": {
+                      "col": 9,
+                      "end_col": 11,
+                      "end_lnum": 69,
+                      "lnum": 69
+                    }
+                  }
+                ],
+                "col": 6,
+                "end_col": 11,
+                "end_lnum": 82,
+                "kind": "Struct",
+                "level": 3,
+                "lnum": 39,
+                "name": "ul",
+                "selection_range": {
+                  "col": 7,
+                  "end_col": 9,
+                  "end_lnum": 39,
+                  "lnum": 39
+                }
+              }
+            ],
+            "col": 4,
+            "end_col": 10,
+            "end_lnum": 83,
+            "kind": "Struct",
+            "level": 2,
+            "lnum": 3,
+            "name": "div",
+            "selection_range": {
+              "col": 5,
+              "end_col": 8,
+              "end_lnum": 3,
+              "lnum": 3
+            }
+          }
+        ],
+        "col": 2,
+        "end_col": 8,
+        "end_lnum": 84,
+        "kind": "Struct",
+        "level": 1,
+        "lnum": 2,
+        "name": "nav",
+        "selection_range": {
+          "col": 3,
+          "end_col": 6,
+          "end_lnum": 2,
+          "lnum": 2
+        }
+      }
+    ],
+    "col": 0,
+    "end_col": 11,
+    "end_lnum": 85,
+    "kind": "Struct",
+    "level": 0,
+    "lnum": 1,
+    "name": "template",
+    "selection_range": {
+      "col": 1,
+      "end_col": 9,
+      "end_lnum": 1,
+      "lnum": 1
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 9,
+    "end_lnum": 96,
+    "kind": "Struct",
+    "level": 0,
+    "lnum": 87,
+    "name": "script",
+    "selection_range": {
+      "col": 1,
+      "end_col": 7,
+      "end_lnum": 87,
+      "lnum": 87
+    }
+  }
+]

--- a/tests/treesitter/css_test.css
+++ b/tests/treesitter/css_test.css
@@ -1,0 +1,169 @@
+/*
+ * kerb.css
+ * ~~~~~~~~~~~
+ *
+ * Sphinx stylesheet -- modification to agogo theme.
+ *
+ */
+div.body {
+  padding-right: .5em;
+  text-align: left;
+  overflow-x: hidden;
+}
+
+/* Page layout */
+
+div.header, div.content, div.footer {
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 1em;
+  padding-right: 1em;
+  max-width: 60em;
+}
+
+div.header-wrapper {
+  background: white;
+  border-bottom: 3px solid #2e3436;
+  border-top: 13px solid #5d1509;
+}
+
+/* Header */
+
+div.header {
+  padding-top: 10px;
+  padding-bottom: 0px;
+}
+
+div.header h1 {
+  font-family: "Georgia", "Times New Roman", serif,  black;
+  font-weight: normal;
+}
+
+div.header h1 a {
+  color: #5d1509;
+  font-size: 120%;
+  padding-top: 10px;
+}
+
+div.header div.right a {
+  color: #fcaf3e;
+  letter-spacing: .1em;
+  text-transform: lowercase;
+  float: right;
+}
+
+div.header div.rel {
+  font-family: "Georgia", "Times New Roman", serif, black;
+  font-weight: normal;
+  margin-bottom: 1.6em;
+}
+
+/* Content */
+
+div.document {
+  width: 80%;
+  float: left;
+  margin: 0;
+  background-color: white;
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+
+div.document div.section h1 {
+  margin-bottom: 20px;
+  padding: 1px;
+  line-height: 130%;
+}
+
+div.document div.section dl {
+  margin-top: 15px;
+  margin-bottom: 5px;
+  padding: 1px;
+  text-align: left;
+}
+
+/* Sidebar */
+
+div.sidebar {
+  float: right;
+  font-size: .9em;
+  width: 20%;
+  margin: 0;
+  padding: 0;
+  background-color: #F9F9F9;
+}
+
+div.sidebar ul {
+  list-style-type: none;
+  margin-left: .5em;
+}
+
+div.sidebar li.toctree-l1 a {
+  margin-left: .5em;
+}
+
+div.sidebar li.toctree-l2 a {
+  margin-left: .5em;
+}
+
+div.sidebar li.toctree-l3 a {
+  margin-left: .5em;
+}
+
+div.sidebar li.toctree-l2.current a {
+  border-right: 2px solid #fcaf3e  !important;
+}
+
+div.sidebar li.toctree-l3.current a {
+  font-weight: bold;
+}
+
+div.sidebar li.toctree-l4 a {
+  display: none;
+}
+
+div.sidebar input[type=text] {
+  width: auto;
+}
+
+/* Other body styles */
+
+dt:target, .highlighted {
+  background-color: #c1c1c1;
+}
+
+/* Code displays */
+
+pre {
+    overflow: auto;
+    overflow-y: hidden;
+}
+
+td.linenos pre {
+    padding: 5px 0px;
+    border: 0;
+    background-color: transparent;
+    color: #aaa;
+}
+
+/* ordered lists */
+
+ol.arabic {
+    list-style: decimal;
+}
+
+ol.loweralpha {
+    list-style: lower-alpha;
+}
+
+ol.upperalpha {
+    list-style: upper-alpha;
+}
+
+ol.lowerroman {
+    list-style-type: lower-roman;
+}
+
+ol.upperroman {
+    list-style-type: upper-roman;
+}

--- a/tests/treesitter/ini_test.ini
+++ b/tests/treesitter/ini_test.ini
@@ -1,0 +1,24 @@
+[core]
+# enable xwayland for X11 apps
+xwayland=true
+
+[libinput]
+enable-tap=true
+
+[shell]
+background-image=/home/rmuir/.fvwm/.BGdefault
+panel-position=bottom
+animation=zoom
+cursor-size=16
+
+[keyboard]
+keymap_model=thinkpad
+vt-switching=true
+
+[launcher]
+icon=/usr/share/weston/terminal.png
+path=/usr/bin/alacritty
+
+[launcher]
+icon=/usr/share/weston/terminal.png
+path=MOZ_ENABLE_WAYLAND=1 /usr/bin/firefox

--- a/tests/treesitter/terraform_test.tf
+++ b/tests/treesitter/terraform_test.tf
@@ -1,0 +1,21 @@
+provider "aws" {
+  region = "${var.region}"
+}
+
+resource "aws_vpc" "demo_vpc" {
+  cidr_block = "${var.vpc_cidr_block}"
+
+  tags {
+    Name = "fp_demo_vpc"
+  }
+}
+
+resource "aws_subnet" "demo_subnet" {
+  vpc_id            = "${aws_vpc.demo_vpc.id}"
+  cidr_block        = "${var.subnet_cidr_block}"
+  availability_zone = "${var.subnet_availability_zone}"
+
+  tags {
+    Name = "fp_demo_subnet"
+  }
+}

--- a/tests/treesitter/vue_test.vue
+++ b/tests/treesitter/vue_test.vue
@@ -1,0 +1,96 @@
+<template>
+  <nav class="navbar navbar-light">
+    <div class="container">
+      <router-link class="navbar-brand" :to="{ name: 'home' }">
+        conduit
+      </router-link>
+      <ul v-if="!isAuthenticated" class="nav navbar-nav pull-xs-right">
+        <li class="nav-item">
+          <router-link
+            class="nav-link"
+            active-class="active"
+            exact
+            :to="{ name: 'home' }"
+          >
+            Home
+          </router-link>
+        </li>
+        <li class="nav-item">
+          <router-link
+            class="nav-link"
+            active-class="active"
+            exact
+            :to="{ name: 'login' }"
+          >
+            <i class="ion-compose"></i>Sign in
+          </router-link>
+        </li>
+        <li class="nav-item">
+          <router-link
+            class="nav-link"
+            active-class="active"
+            exact
+            :to="{ name: 'register' }"
+          >
+            <i class="ion-compose"></i>Sign up
+          </router-link>
+        </li>
+      </ul>
+      <ul v-else class="nav navbar-nav pull-xs-right">
+        <li class="nav-item">
+          <router-link
+            class="nav-link"
+            active-class="active"
+            exact
+            :to="{ name: 'home' }"
+          >
+            Home
+          </router-link>
+        </li>
+        <li class="nav-item">
+          <router-link
+            class="nav-link"
+            active-class="active"
+            :to="{ name: 'article-edit' }"
+          >
+            <i class="ion-compose"></i>&nbsp;New Article
+          </router-link>
+        </li>
+        <li class="nav-item">
+          <router-link
+            class="nav-link"
+            active-class="active"
+            exact
+            :to="{ name: 'settings' }"
+          >
+            <i class="ion-gear-a"></i>&nbsp;Settings
+          </router-link>
+        </li>
+        <li class="nav-item" v-if="currentUser.username">
+          <router-link
+            class="nav-link"
+            active-class="active"
+            exact
+            :to="{
+              name: 'profile',
+              params: { username: currentUser.username }
+            }"
+          >
+            {{ currentUser.username }}
+          </router-link>
+        </li>
+      </ul>
+    </div>
+  </nav>
+</template>
+
+<script>
+import { mapGetters } from "vuex";
+
+export default {
+  name: "RwvHeader",
+  computed: {
+    ...mapGetters(["currentUser", "isAuthenticated"])
+  }
+};
+</script>


### PR DESCRIPTION
Add simple queries for these popular filetypes.

- css finds blocks named by selector, just like the css LSP
- ini finds sections
- terraform finds blocks named by string literals
- vue inherits the queries from html (nvim-treesitter approach)

Thank you for aerial.nvim! I have several other languages and improvements to some existing ones, but I don't want to flood you with PRs, esp. for these very simple ones. Happy to split this up into separate PRs if you prefer that though.