### PR TITLE
feat(make): refine query for make symbols

### DIFF
--- a/queries/make/aerial.scm
+++ b/queries/make/aerial.scm
@@ -1,3 +1,11 @@
+; capture each target name from the list
 (rule
-  (targets) @name
-  (#set! "kind" "Interface")) @symbol
+  (targets
+    (_) @name @symbol)
+  ; exclude special names that aren't actually targets
+  ; https://www.gnu.org/software/make/manual/html_node/Special-Targets.html
+  (#not-any-of? @name
+    ".PHONY" ".SUFFIXES" ".DEFAULT" ".PRECIOUS" ".INTERMEDIATE" ".NOTINTERMEDIATE" ".SECONDARY"
+    ".SECONDEXPANSION" ".DELETE_ON_ERROR" ".IGNORE" ".LOW_RESOLUTION_TIME" ".SILENT"
+    ".EXPORT_ALL_VARIABLES" ".NOTPARALLEL" ".ONESHELL" ".POSIX")
+  (#set! "kind" "Interface")) @start

--- a/tests/symbols/Makefile.json
+++ b/tests/symbols/Makefile.json
@@ -17,7 +17,7 @@
   {
     "col": 0,
     "end_col": 0,
-    "end_lnum": 6,
+    "end_lnum": 7,
     "kind": "Interface",
     "level": 0,
     "lnum": 4,
@@ -27,6 +27,36 @@
       "end_col": 6,
       "end_lnum": 4,
       "lnum": 4
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 9,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 8,
+    "name": "target1",
+    "selection_range": {
+      "col": 0,
+      "end_col": 7,
+      "end_lnum": 8,
+      "lnum": 8
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 9,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 8,
+    "name": "$(target2)",
+    "selection_range": {
+      "col": 8,
+      "end_col": 18,
+      "end_lnum": 8,
+      "lnum": 8
     }
   }
 ]

--- a/tests/treesitter/Makefile
+++ b/tests/treesitter/Makefile
@@ -3,3 +3,6 @@ all: foo bar
 
 out.so:
 	touch out.so
+
+.PHONY: target1
+target1 $(target2): all


### PR DESCRIPTION
Previously the entire list of targets was captured as a single symbol: instead capture each target. vim's Makefile is an example that makes use of this feature.

Exclude targets that aren't targets from the "special target list": these are not symbols. This is a minor improvement for Makefiles such as the aerial.nvim Makefile, which only declares `.PHONY` a single time, but it is a large noise-reducer for cases such as nvim-treesitter Makefile, which lists `.PHONY` before each phony target.