### PR TITLE
fix(c): remove buggy query pattern

### DIFF
--- a/queries/c/aerial.scm
+++ b/queries/c/aerial.scm
@@ -8,10 +8,5 @@
   declarator: (type_identifier) @name
   (#set! "kind" "Struct")) @start
 
-((declaration) @root @start
-  .
-  (function_definition) @symbol @end
-  (#set! "kind" "Function"))
-
 (function_definition
   (#set! "kind" "Function")) @symbol @root

--- a/tests/symbols/c_test.json
+++ b/tests/symbols/c_test.json
@@ -103,5 +103,80 @@
       "end_lnum": 19,
       "lnum": 19
     }
+  },
+  {
+    "col": 0,
+    "end_col": 1,
+    "end_lnum": 25,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 23,
+    "name": "foo",
+    "selection_range": {
+      "col": 4,
+      "end_col": 7,
+      "end_lnum": 23,
+      "lnum": 23
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 1,
+    "end_lnum": 29,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 27,
+    "name": "bar",
+    "selection_range": {
+      "col": 4,
+      "end_col": 7,
+      "end_lnum": 27,
+      "lnum": 27
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 1,
+    "end_lnum": 36,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 32,
+    "name": "fn_kr",
+    "selection_range": {
+      "col": 4,
+      "end_col": 9,
+      "end_lnum": 32,
+      "lnum": 32
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 1,
+    "end_lnum": 41,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 39,
+    "name": "fn_specifiers",
+    "selection_range": {
+      "col": 18,
+      "end_col": 31,
+      "end_lnum": 39,
+      "lnum": 39
+    }
+  },
+  {
+    "col": 0,
+    "end_col": 1,
+    "end_lnum": 49,
+    "kind": "Function",
+    "level": 0,
+    "lnum": 44,
+    "name": "fn_macro_attributes",
+    "selection_range": {
+      "col": 7,
+      "end_col": 26,
+      "end_lnum": 44,
+      "lnum": 44
+    }
   }
 ]

--- a/tests/treesitter/c_test.c
+++ b/tests/treesitter/c_test.c
@@ -17,3 +17,33 @@ typedef enum {
 typedef struct {
   int field;
 } St_1;
+
+int var = 5;
+
+int foo() {
+  return 0;
+}
+
+int bar() {
+  return 0;
+}
+
+// K&R style
+int fn_kr(bar, baz, qux)
+int bar, baz;
+char *qux;
+{
+}
+
+// specifiers after types
+int static inline fn_specifiers(int arg1) {
+  return 5;
+}
+
+// fn definition with macro attributes
+void * fn_macro_attributes(int arg1)
+  SOME_ATTR
+  SOME_ATTR(1)
+{
+  return 5;
+}


### PR DESCRIPTION
Reported bug of missing functions (#413) is caused by this query pattern:

```
((declaration) @root @start
  .
  (function_definition) @symbol @end
  (#set! "kind" "Function"))
```

Removing the pattern fixes the bug and causes no regressions in tests. The pattern was introduced in https://github.com/stevearc/aerial.nvim/commit/91350456c176fe5ef72e342dd3a75f726805454d but it is not clear what its purpose is: all functions should be matched by the simple `(function_definition)` query immediately after it.

The example from #413 and a few additional tests from tree-sitter-c's test corpus were added.

Closes #413

Note: if by any chance you happen to remember what this pattern was trying to accomplish, I can look to address/test for it.