### PR TITLE
feat: treesitter queries for editorconfig, hcl, ssh_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,13 @@ In addition, you will need to have either Treesitter or a working LSP client. Yo
 - css
 - dart
 - djot
+- editorconfig
 - elixir
 - enforce
 - fish
 - go
 - groovy
+- hcl
 - help
 - html
 - ini
@@ -176,6 +178,7 @@ In addition, you will need to have either Treesitter or a working LSP client. Yo
 - scala
 - snakemake
 - solidity
+- ssh_config
 - starlark
 - swift
 - teal

--- a/queries/editorconfig/aerial.scm
+++ b/queries/editorconfig/aerial.scm
@@ -1,0 +1,21 @@
+; single glob, e.g. [*.foo]
+(section
+  (section_name
+    [
+      (character)
+      (integer_range)
+      (path_separator)
+      (character_choice)
+      (escaped_character)
+      (wildcard_characters)
+      (wildcard_any_characters)
+      (wildcard_single_character)
+    ]) @name @symbol
+  (#set! "kind" "Class"))
+
+; multiple globs in braces, e.g. [{*.foo,*.bar}]
+(section
+  (section_name
+    (brace_expansion
+      (expansion_string) @name @symbol))
+  (#set! "kind" "Class"))

--- a/queries/hcl/aerial.scm
+++ b/queries/hcl/aerial.scm
@@ -1,0 +1,5 @@
+; blocks
+(block
+  (string_lit
+    (template_literal) @name @symbol)
+  (#set! "kind" "Class"))

--- a/queries/ssh_config/aerial.scm
+++ b/queries/ssh_config/aerial.scm
@@ -1,0 +1,10 @@
+; host sections
+(host_declaration
+  argument: (_) @name @symbol
+  (#set! "kind" "Interface"))
+
+; match sections
+(match_declaration
+  (condition
+    (_) @name @symbol)
+  (#set! "kind" "Interface"))

--- a/queries/terraform/aerial.scm
+++ b/queries/terraform/aerial.scm
@@ -1,5 +1,1 @@
-; blocks
-(block
-  (string_lit
-    (template_literal) @name @symbol)
-  (#set! "kind" "Class"))
+; inherits: hcl

--- a/tests/symbols/editorconfig.json
+++ b/tests/symbols/editorconfig.json
@@ -1,0 +1,92 @@
+[
+  {
+    "col": 1,
+    "end_col": 2,
+    "end_lnum": 4,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 4,
+    "name": "*",
+    "selection_range": {
+      "col": 1,
+      "end_col": 2,
+      "end_lnum": 4,
+      "lnum": 4
+    }
+  },
+  {
+    "col": 2,
+    "end_col": 7,
+    "end_lnum": 11,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 11,
+    "name": "*.txt",
+    "selection_range": {
+      "col": 2,
+      "end_col": 7,
+      "end_lnum": 11,
+      "lnum": 11
+    }
+  },
+  {
+    "col": 8,
+    "end_col": 15,
+    "end_lnum": 11,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 11,
+    "name": "*.patch",
+    "selection_range": {
+      "col": 8,
+      "end_col": 15,
+      "end_lnum": 11,
+      "lnum": 11
+    }
+  },
+  {
+    "col": 1,
+    "end_col": 9,
+    "end_lnum": 15,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 15,
+    "name": "Makefile",
+    "selection_range": {
+      "col": 1,
+      "end_col": 9,
+      "end_lnum": 15,
+      "lnum": 15
+    }
+  },
+  {
+    "col": 1,
+    "end_col": 7,
+    "end_lnum": 19,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 19,
+    "name": "*.java",
+    "selection_range": {
+      "col": 1,
+      "end_col": 7,
+      "end_lnum": 19,
+      "lnum": 19
+    }
+  },
+  {
+    "col": 1,
+    "end_col": 12,
+    "end_lnum": 22,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 22,
+    "name": "folder/*.py",
+    "selection_range": {
+      "col": 1,
+      "end_col": 12,
+      "end_lnum": 22,
+      "lnum": 22
+    }
+  }
+]

--- a/tests/symbols/hcl_test.json
+++ b/tests/symbols/hcl_test.json
@@ -1,0 +1,47 @@
+[
+  {
+    "col": 7,
+    "end_col": 14,
+    "end_lnum": 1,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 1,
+    "name": "default",
+    "selection_range": {
+      "col": 7,
+      "end_col": 14,
+      "end_lnum": 1,
+      "lnum": 1
+    }
+  },
+  {
+    "col": 8,
+    "end_col": 11,
+    "end_lnum": 5,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 5,
+    "name": "app",
+    "selection_range": {
+      "col": 8,
+      "end_col": 11,
+      "end_lnum": 5,
+      "lnum": 5
+    }
+  },
+  {
+    "col": 8,
+    "end_col": 13,
+    "end_lnum": 16,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 16,
+    "name": "infra",
+    "selection_range": {
+      "col": 8,
+      "end_col": 13,
+      "end_lnum": 16,
+      "lnum": 16
+    }
+  }
+]

--- a/tests/symbols/ssh_config.json
+++ b/tests/symbols/ssh_config.json
@@ -1,0 +1,62 @@
+[
+  {
+    "col": 5,
+    "end_col": 9,
+    "end_lnum": 3,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 3,
+    "name": "dev0",
+    "selection_range": {
+      "col": 5,
+      "end_col": 9,
+      "end_lnum": 3,
+      "lnum": 3
+    }
+  },
+  {
+    "col": 5,
+    "end_col": 17,
+    "end_lnum": 8,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 8,
+    "name": "*.foobar.com",
+    "selection_range": {
+      "col": 5,
+      "end_col": 17,
+      "end_lnum": 8,
+      "lnum": 8
+    }
+  },
+  {
+    "col": 5,
+    "end_col": 13,
+    "end_lnum": 13,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 13,
+    "name": "logerrit",
+    "selection_range": {
+      "col": 5,
+      "end_col": 13,
+      "end_lnum": 13,
+      "lnum": 13
+    }
+  },
+  {
+    "col": 14,
+    "end_col": 36,
+    "end_lnum": 13,
+    "kind": "Interface",
+    "level": 0,
+    "lnum": 13,
+    "name": "gerrit.libreoffice.org",
+    "selection_range": {
+      "col": 14,
+      "end_col": 36,
+      "end_lnum": 13,
+      "lnum": 13
+    }
+  }
+]

--- a/tests/treesitter/editorconfig
+++ b/tests/treesitter/editorconfig
@@ -1,0 +1,23 @@
+# vim: set filetype=editorconfig:
+root = true
+
+[*]
+charset = utf-8
+indent_size = 2
+ij_formatter_off_tag = @formatter:off
+ij_formatter_on_tag = @formatter:on
+ij_visual_guides =
+
+[{*.txt,*.patch}]
+# indent doesn't make sense for these
+indent_size = unset
+
+[Makefile]
+indent_size = 4
+indent_style = tab
+
+[*.java]
+ij_java_wrap_comments = true
+
+[folder/*.py]
+indent_size = 4

--- a/tests/treesitter/hcl_test.hcl
+++ b/tests/treesitter/hcl_test.hcl
@@ -1,0 +1,25 @@
+group "default" {
+  targets = ["app", "infra"]
+}
+
+target "app" {
+  context    = "."
+  dockerfile = "images/app/Dockerfile"
+  platforms = ["linux/amd64", "linux/arm64"]
+  tags = ["${REPO_URL}/app_bake:${IMAGE_TAG_VERSION_APP}"]
+  attest = [
+    "type=provenance,mode=max",
+    "type=sbom"
+  ]
+}
+
+target "infra" {
+  context    = "."
+  dockerfile = "images/infra/Dockerfile"
+  platforms = ["linux/amd64", "linux/arm64"]
+  tags = ["${REPO_URL}/infra_bake:${IMAGE_TAG_VERSION_INFRA}"]
+  attest = [
+    "type=provenance,mode=max",
+    "type=sbom"
+  ]
+}

--- a/tests/treesitter/ssh_config
+++ b/tests/treesitter/ssh_config
@@ -1,0 +1,15 @@
+AddKeysToAgent yes
+
+Host dev0
+  UserKnownHostsFile ~/.ssh/known_vm_hosts
+  Hostname localhost
+  Port 10022
+
+Host *.foobar.com
+  User ec2-user
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+
+Host logerrit gerrit.libreoffice.org
+  Port 29418
+  Hostname gerrit.libreoffice.org


### PR DESCRIPTION
Terraform is a different treesitter parser than hcl, but for aerial purposes these are the same. Support hcl also, it is helpful for docker bake files at least.

ssh_config / editorconfig are a few more "devops" formats with simple "sections", aerial helps when the files are large. The editorconfig pattern is a bit strange, but this is due to the grammar: any fancy stuff such as `not-kind-eq` is avoided since this predicate isn't in neovim core.