### PR TITLE
feat(yaml): treesitter name array elements symbol based upon "name" key

### DIFF
--- a/queries/yaml/aerial.scm
+++ b/queries/yaml/aerial.scm
@@ -9,3 +9,19 @@
   value: (block_node
     (block_sequence) @symbol)
   (#set! "kind" "Enum")) @start
+
+; "array element" with a "name:" key
+; ansible play/task names, etc
+; github workflow/actions jobs/steps, etc
+(block_sequence_item
+  (block_node
+    (block_mapping
+      (block_mapping_pair
+        key: (flow_node
+          (plain_scalar
+            (string_scalar) @_key))
+        value: (flow_node
+          (plain_scalar
+            (string_scalar) @name)))))
+  (#eq? @_key "name")
+  (#set! "kind" "Module")) @symbol

--- a/tests/symbols/yaml_test2.json
+++ b/tests/symbols/yaml_test2.json
@@ -1,0 +1,83 @@
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "col": 6,
+                "end_col": 40,
+                "end_lnum": 15,
+                "kind": "Module",
+                "level": 3,
+                "lnum": 10,
+                "name": "Prepare",
+                "selection_range": {
+                  "col": 14,
+                  "end_col": 21,
+                  "end_lnum": 10,
+                  "lnum": 10
+                }
+              },
+              {
+                "col": 6,
+                "end_col": 0,
+                "end_lnum": 19,
+                "kind": "Module",
+                "level": 3,
+                "lnum": 17,
+                "name": "Run Luacheck",
+                "selection_range": {
+                  "col": 14,
+                  "end_col": 26,
+                  "end_lnum": 17,
+                  "lnum": 17
+                }
+              }
+            ],
+            "col": 4,
+            "end_col": 0,
+            "end_lnum": 19,
+            "kind": "Enum",
+            "level": 2,
+            "lnum": 7,
+            "name": "steps",
+            "selection_range": {
+              "col": 4,
+              "end_col": 9,
+              "end_lnum": 7,
+              "lnum": 7
+            }
+          }
+        ],
+        "col": 2,
+        "end_col": 0,
+        "end_lnum": 19,
+        "kind": "Class",
+        "level": 1,
+        "lnum": 4,
+        "name": "luacheck",
+        "selection_range": {
+          "col": 2,
+          "end_col": 10,
+          "end_lnum": 4,
+          "lnum": 4
+        }
+      }
+    ],
+    "col": 0,
+    "end_col": 0,
+    "end_lnum": 19,
+    "kind": "Class",
+    "level": 0,
+    "lnum": 3,
+    "name": "jobs",
+    "selection_range": {
+      "col": 0,
+      "end_col": 4,
+      "end_lnum": 3,
+      "lnum": 3
+    }
+  }
+]

--- a/tests/treesitter/yaml_test2.yml
+++ b/tests/treesitter/yaml_test2.yml
@@ -1,0 +1,18 @@
+name: Run tests
+
+jobs:
+  luacheck:
+    name: Luacheck
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare
+        run: |
+          sudo apt-get update
+          sudo add-apt-repository universe
+          sudo apt install luarocks -y
+          sudo luarocks install luacheck
+
+      - name: Run Luacheck
+        run: luacheck lua tests


### PR DESCRIPTION
Previously, these elements were not listed as symbols. redhat's yaml-language-server lists these as numbered elements such as 0, 1, 2, but treesitter strategy didn't match them at all.

There's a de-facto standard for many yaml formats, to use the "name" key to solve this problem. It is a best practice for commonly used yaml files such as github workflows and ansible.

Note: I can tune the query if there are concerns: I'm aware this looks a bit strange, but it really makes these files possible to navigate, and doesn't hurt anything else (only introduces symbol where one didn't exist before). Try it out on some actions/ansible files.

<img width="352" height="1026" alt="Screen_Shot_2025-09-02_at_02 14 57" src="https://github.com/user-attachments/assets/f92a2b72-7a01-4586-aaf0-3734300cc0dc" />
