### PR TITLE
fix: eliminate flash when opening nav window

### DIFF
--- a/lua/aerial/nav_view.lua
+++ b/lua/aerial/nav_view.lua
@@ -379,6 +379,7 @@ M.open = function()
       _active_nav:focus_symbol(pos.closest_symbol)
     end
   end
+  _active_nav:relayout()
 end
 
 M.toggle = function()


### PR DESCRIPTION
The nav windows are created at a temporary position (row=1, col=1) and then repositioned to center, causing a brief flash in the top-left.

By creating windows with hide=true and revealing them after positioning, we can suppress this flash.

I tested this patch on my local machine (Windows 11, WSL in Windows Terminal, Fedora Linux guest) and it seems to work for me. Let me know if any changes are needed. Thanks.