### PR TITLE
fix: navigate to symbol with Snacks in scratch buf

### DIFF
--- a/lua/aerial/snacks.lua
+++ b/lua/aerial/snacks.lua
@@ -3,6 +3,7 @@ local config = require("aerial.config")
 local data = require("aerial.data")
 local highlight = require("aerial.highlight")
 local navigation = require("aerial.navigation")
+
 local M = {}
 ---@module 'snacks.picker'
 


### PR DESCRIPTION
An absolute delight in my day, was discovering `require("aerial").snacks_picker()`. Previously I'd used `<cmd>AerialToggle float<CR>` and whilst it was convenient, it took too many keystrokes to navigate to where I wanted to get to.

I started using Aerial and Snacks with CodeCompanion in order to navigate between H2 headers and I noticed that when selecting a symbol, I hit a position error and then when I reopened the CodeCompanion buffer (which circumvents the error it seems) and selected a symbol, the cursor moved to that symbol but in another window:

**with error**:

https://github.com/user-attachments/assets/0226fba2-f6d7-49da-a82f-ac2f4acb9564

This PR adds a `confirm` action to the Snacks picker which uses aerial's navigation module to determine where to move to:

**without error**:

https://github.com/user-attachments/assets/1e6bee85-3750-42f8-9e24-6ce1828930d0

I haven't investigated further but it seemed that because CodeCompanion buffers are of the scratch variety and `buftype=nofile`, that interfered with something.