### PR TITLE
FIX: Missing end_col value in asciidoc.lua causes errors on line 404 in window.lua.

### DIFF
--- a/lua/aerial/backends/asciidoc.lua
+++ b/lua/aerial/backends/asciidoc.lua
@@ -37,7 +37,7 @@ M.fetch_symbols_sync = function(bufnr)
         lnum = lnum,
         col = 0,
         end_lnum = lnum,
-        end_col = 999,
+        end_col = line:len(),
       }
       if parent then
         if not parent.children then

--- a/lua/aerial/backends/asciidoc.lua
+++ b/lua/aerial/backends/asciidoc.lua
@@ -37,6 +37,7 @@ M.fetch_symbols_sync = function(bufnr)
         lnum = lnum,
         col = 0,
         end_lnum = lnum,
+        end_col = 999,
       }
       if parent then
         if not parent.children then

--- a/tests/symbols/asciidoc_backend.snapshot
+++ b/tests/symbols/asciidoc_backend.snapshot
@@ -1,6 +1,6 @@
-Interface Title 1|1:0-1
-  Interface Title 2|3:0-3
-    Interface Title 3|5:0-5
-      Interface Title 4|7:0-7
-        Interface Title 5|9:0-9
-  Interface title2|11:0-11
+Interface Title 1|1:0-1:9
+  Interface Title 2|3:0-3:10
+    Interface Title 3|5:0-5:11
+      Interface Title 4|7:0-7:12
+        Interface Title 5|9:0-9:13
+  Interface title2|11:0-11:9


### PR DESCRIPTION
Error introduced by correction in commit 68124b, causing "if" evaluation in windows.lua at line 404 to test against a nil value (the missing end_col value).

This bug was hiding if the cursor was at the leftmost position.