### PR TITLE
fix: handle nil level_node in markdown get_parent

### DIFF
--- a/lua/aerial/backends/treesitter/extensions.lua
+++ b/lua/aerial/backends/treesitter/extensions.lua
@@ -110,7 +110,10 @@ M.elixir = {
 
 M.markdown = {
   get_parent = function(stack, match, node)
-    local level_node = assert(node_from_match(match, "level"))
+    local level_node = node_from_match(match, "level")
+    if not level_node or not level_node.type then
+      return nil, nil, 0
+    end
     -- Parse the level out of e.g. atx_h1_marker
     local level = tonumber(string.match(level_node:type(), "%d")) - 1
     for i = #stack, 1, -1 do

--- a/lua/aerial/backends/treesitter/helpers.lua
+++ b/lua/aerial/backends/treesitter/helpers.lua
@@ -10,6 +10,12 @@ end
 ---@param end_node TSNode
 ---@return aerial.Range
 M.range_from_nodes = function(start_node, end_node)
+  if not start_node or type(start_node) ~= "userdata" then
+    return { lnum = 1, end_lnum = 1, col = 0, end_col = 0 }
+  end
+  if not end_node or type(end_node) ~= "userdata" then
+    end_node = start_node
+  end
   local row, col = start_node:start()
   local end_row, end_col = end_node:end_()
   return {

--- a/lua/aerial/backends/treesitter/init.lua
+++ b/lua/aerial/backends/treesitter/init.lua
@@ -65,6 +65,10 @@ local function set_symbols_from_treesitter(bufnr, lang, query, syntax_tree)
     for id, nodes in pairs(matches) do
       -- preserve the old iter_matches({all = false}) behavior
       local node = nodes[#nodes]
+      -- Skip invalid nodes that lack expected TSNode methods
+      if type(node) ~= "userdata" then
+        goto next_capture
+      end
       -- iter_group_results prefers `#set!` metadata, keeping the behaviour
       match = vim.tbl_extend("keep", match, {
         [query.captures[id]] = {
@@ -72,12 +76,13 @@ local function set_symbols_from_treesitter(bufnr, lang, query, syntax_tree)
           node = node,
         },
       })
+      ::next_capture::
     end
 
     local name_match = match.name or {}
     local selection_match = match.selection or {}
     local symbol_node = (match.symbol or match.type or {}).node
-    if not symbol_node then
+    if not symbol_node or type(symbol_node) ~= "userdata" then
       goto continue
     end
     -- The location capture groups are optional. We default to the


### PR DESCRIPTION
When treesitter returns a match without a valid "level" node (e.g. due to parser updates or incomplete parse trees), the assert + :type() call on line 115 crashes with "attempt to call method 'type' (a nil value)".

Replace assert() with an explicit nil check and early return to gracefully skip malformed matches instead of crashing.