### PR TITLE
fix: use node:range() instead of deprecated node:start()

### DIFF
--- a/lua/aerial/backends/treesitter/extensions.lua
+++ b/lua/aerial/backends/treesitter/extensions.lua
@@ -180,7 +180,7 @@ M.help = {
     local node = match.name.node
     if vim.startswith(node_from_match(match, "symbol"):type(), "h") then
       while node and node:type() == "word" do
-        local row, col = node:start()
+        local row, col, _, _ = node:range()
         table.insert(pieces, 1, get_node_text(node, bufnr))
         node = node:prev_sibling()
         item.lnum = row + 1

--- a/lua/aerial/backends/treesitter/extensions.lua
+++ b/lua/aerial/backends/treesitter/extensions.lua
@@ -180,7 +180,7 @@ M.help = {
     local node = match.name.node
     if vim.startswith(node_from_match(match, "symbol"):type(), "h") then
       while node and node:type() == "word" do
-        local row, col, _, _ = node:range()
+        local row, col = node:range()
         table.insert(pieces, 1, get_node_text(node, bufnr))
         node = node:prev_sibling()
         item.lnum = row + 1

--- a/lua/aerial/backends/treesitter/helpers.lua
+++ b/lua/aerial/backends/treesitter/helpers.lua
@@ -10,12 +10,11 @@ end
 ---@param end_node TSNode
 ---@return aerial.Range
 M.range_from_nodes = function(start_node, end_node)
-  local row, col = start_node:start()
-  local end_row, end_col = end_node:end_()
+  local start_row, start_col, end_row, end_col = start_node:range()
   return {
-    lnum = row + 1,
+    lnum = start_row + 1,
     end_lnum = end_row + 1,
-    col = col,
+    col = start_col,
     end_col = end_col,
   }
 end


### PR DESCRIPTION
In Nvim 0.12, node:start() has been deprecated, causing aerial to crash when calling it in helpers.lua. This PR replaces it with modern node:range() function.