### PR TITLE
feat(sibling_jump): move to items on the same level

### DIFF
--- a/lua/aerial/init.lua
+++ b/lua/aerial/init.lua
@@ -344,6 +344,20 @@ M.next = lazy("navigation", "next", true)
 ---@param step? integer Number of symbols to jump by (default 1)
 M.prev = lazy("navigation", "prev", true)
 
+local nav_sibling = lazy("navigation", "jump_sibling", true)
+
+---Jump to a symbol at the same level of the tree, moving forwards
+---@param count? integer Distance of the node to jump to (default 1)
+M.next_sibling = function(count)
+  nav_sibling(1, count)
+end
+
+---Jump to a symbol at the same level of the tree, moving backwards
+---@param count? integer Distance of the node to jump to (default 1)
+M.prev_sibling = function(count)
+  nav_sibling(-1, count)
+end
+
 local nav_up = lazy("navigation", "up", true)
 
 ---Jump to a symbol higher in the tree, moving forwards

--- a/lua/aerial/navigation.lua
+++ b/lua/aerial/navigation.lua
@@ -57,6 +57,60 @@ end
 
 ---@param direction? integer -1 for backwards or 1 for forwards
 ---@param count? integer
+M.jump_sibling = function(direction, count)
+  direction = direction or 1
+  count = count or 1
+  local winid = get_target_win()
+  if not winid then
+    error("Could not find destination window")
+    return
+  end
+  local pos = _get_current_lnum(winid)
+  if pos == nil then
+    return
+  end
+  local bufnr, _ = util.get_buffers()
+  local bufdata = data.get_or_create(bufnr)
+
+  -- Find current item
+  local item
+  for _, candidate, i in bufdata:iter({ skip_hidden = true }) do
+    if i == pos.lnum then
+      item = candidate
+    end
+  end
+
+  -- If current item is level 0, the operation is equivalent to `up`
+  if item.level == 0 then
+    M.up(direction, count)
+    return
+  end
+
+  local siblings = item.parent.children
+  local item_sibling_pos
+  for i, s in pairs(siblings) do
+    if s.idx == item.idx then
+      item_sibling_pos = i
+    end
+  end
+
+  local n = #siblings
+  item_sibling_pos = ((item_sibling_pos + (direction * count) - 1) % n + n) % n + 1
+  item = siblings[item_sibling_pos]
+
+  local index = bufdata:indexof(item)
+  M.select({
+    index = index,
+    jump = false,
+    winid = winid,
+  })
+  if util.is_aerial_buffer() then
+    vim.api.nvim_win_set_cursor(0, { index, 0 })
+  end
+end
+
+---@param direction? integer -1 for backwards or 1 for forwards
+---@param count? integer
 M.up = function(direction, count)
   direction = direction or -1
   count = count or 1

--- a/tests/navigation_spec.lua
+++ b/tests/navigation_spec.lua
@@ -163,5 +163,21 @@ a.describe("navigation", function()
       aerial.next_up()
       assert.are.same({ 7, 2 }, vim.api.nvim_win_get_cursor(0))
     end)
+
+    a.it("can go to the next sibling in the tree", function()
+      create_md_buf(markdown_nested_content)
+      vim.api.nvim_win_set_cursor(0, { 3, 3 })
+      window.update_position() -- Not sure why the CursorMoved autocmd doesn't fire
+      aerial.next_sibling()
+      assert.are.same({ 5, 3 }, vim.api.nvim_win_get_cursor(0))
+    end)
+
+    a.it("can go to the previous sibling in the tree", function()
+      create_md_buf(markdown_nested_content)
+      vim.api.nvim_win_set_cursor(0, { 3, 3 })
+      window.update_position() -- Not sure why the CursorMoved autocmd doesn't fire
+      aerial.prev_sibling()
+      assert.are.same({ 5, 3 }, vim.api.nvim_win_get_cursor(0))
+    end)
   end)
 end)


### PR DESCRIPTION
Added functions to jump to items on the same level.
If current level is 0, logic is the same as going up the tree, so the function is reused. Otherwise it finds current position among parent's children and updates it.

closes #443