### PR TITLE
fix: update TSNode API for treesitter 0.12 compatibility

### DIFF
--- a/lua/aerial/backends/treesitter/extensions.lua
+++ b/lua/aerial/backends/treesitter/extensions.lua
@@ -180,7 +180,7 @@ M.help = {
     local node = match.name.node
     if vim.startswith(node_from_match(match, "symbol"):type(), "h") then
       while node and node:type() == "word" do
-        local row, col = node:start()
+        local row, col = node:range()
         table.insert(pieces, 1, get_node_text(node, bufnr))
         node = node:prev_sibling()
         item.lnum = row + 1

--- a/lua/aerial/backends/treesitter/helpers.lua
+++ b/lua/aerial/backends/treesitter/helpers.lua
@@ -10,8 +10,8 @@ end
 ---@param end_node TSNode
 ---@return aerial.Range
 M.range_from_nodes = function(start_node, end_node)
-  local row, col = start_node:start()
-  local end_row, end_col = end_node:end_()
+  local row, col = start_node:range()
+  local _, _, end_row, end_col = end_node:range()
   return {
     lnum = row + 1,
     end_lnum = end_row + 1,

--- a/lua/aerial/backends/treesitter/init.lua
+++ b/lua/aerial/backends/treesitter/init.lua
@@ -64,12 +64,12 @@ local function set_symbols_from_treesitter(bufnr, lang, query, syntax_tree)
     --       }
     --- Matches can overlap. The last match wins.
     local match = vim.tbl_extend("force", {}, metadata)
-    for id, node in pairs(matches) do
+    for id, nodes in pairs(matches) do
       -- iter_group_results prefers `#set!` metadata, keeping the behaviour
       match = vim.tbl_extend("keep", match, {
         [query.captures[id]] = {
           metadata = metadata[id],
-          node = node,
+          node = nodes[1],
         },
       })
     end

--- a/lua/telescope/_extensions/aerial.lua
+++ b/lua/telescope/_extensions/aerial.lua
@@ -84,10 +84,12 @@ local function aerial_picker(opts)
     local query = vim.treesitter.query.get(lang, "highlights")
     if query then
       for _, captures, _ in query:iter_matches(root, bufnr, 0, -1, { all = false }) do
-        for id, node in pairs(captures) do
-          local start_row, start_col, _, end_col = node:range()
-          highlights[start_row] = highlights[start_row] or {}
-          table.insert(highlights[start_row], { start_col, end_col, query.captures[id] })
+        for id, nodes in pairs(captures) do
+          for _, node in ipairs(nodes) do
+            local start_row, start_col, _, end_col = node:range()
+            highlights[start_row] = highlights[start_row] or {}
+            table.insert(highlights[start_row], { start_col, end_col, query.captures[id] })
+          end
         end
       end
     end


### PR DESCRIPTION
## Summary
- Fixes #513: `attempt to call method 'start'/'range' (a nil value)` in Neovim 0.12
- Root cause: `query:iter_matches()` in treesitter 0.12 returns captures as `table<integer, TSNode[]>` (array per capture), but the conversion loop stored the entire array as `.node` instead of extracting the first element
- Also replaces deprecated `:start()`/`:end_()` with `:range()` for future-proofing

## Test plan
- [x] Open aerial.nvim nav view on a buffer with treesitter support (lua, typescript, etc.)
- [x] Verify no errors about nil method calls
- [x] Verify symbols display correctly
- [x] Verify help file handling still works (extensions.lua change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)