### PR TITLE
fix(lsp): handle non-string symbol.name from non-conforming servers

### DIFF
--- a/lua/aerial/backends/lsp/callbacks.lua
+++ b/lua/aerial/backends/lsp/callbacks.lua
@@ -55,8 +55,8 @@ local function process_symbols(symbols, bufnr, fix_start_col, client_name)
       end
       local include_item = range and include_kind[kind]
 
-      -- Check symbol.name because some LSP servers return a nil name
-      if include_item and symbol.name then
+      -- Check symbol.name because some LSP servers return a nil or non-string name
+      if include_item and type(symbol.name) == "string" then
         local name = symbol.name
         -- Some LSP servers return multiline symbols with newlines
         local nl = string.find(symbol.name, "\n")


### PR DESCRIPTION
Some LSP servers (matlab-language-server is the one in #500, probably others) return documentSymbol entries whose `name` is a non-string value, causing `string.find(symbol.name, "\n")` at `callbacks.lua:62` to error on every buffer edit:

```
bad argument #1 to 'find' (string expected, got table)
```

Tightens the existing truthy guard to a `type(...) == "string"` check so non-string names are skipped the same way nil names already were. Children of skipped symbols still surface via the existing `elseif symbol.children` branch on the next line.

Closes #500