### PR TITLE
fix: handle iter_matches node arrays from Neovim 0.12+

### DIFF
--- a/lua/aerial/backends/treesitter/init.lua
+++ b/lua/aerial/backends/treesitter/init.lua
@@ -66,6 +66,10 @@ local function set_symbols_from_treesitter(bufnr, lang, query, syntax_tree)
     local match = vim.tbl_extend("force", {}, metadata)
     for id, node in pairs(matches) do
       -- iter_group_results prefers `#set!` metadata, keeping the behaviour
+      -- nvim 0.12+: iter_matches returns a list of nodes per capture
+      if type(node) == "table" then
+        node = node[#node]
+      end
       match = vim.tbl_extend("keep", match, {
         [query.captures[id]] = {
           metadata = metadata[id],


### PR DESCRIPTION
## Summary

Neovim 0.12 changed the behavior of `iter_matches`: each capture now returns a **list of nodes** instead of a single node. This breaks the treesitter backend in aerial with errors like:

```
attempt to call method 'start' (a nil value)
  ...aerial.nvim/lua/aerial/backends/treesitter/helpers.lua:13
attempt to call method 'type' (a nil value)
  ...aerial.nvim/lua/aerial/backends/treesitter/extensions.lua:118
```

## Fix

Normalize the `node` value in the `iter_matches` loop in `init.lua` by unwrapping the table when one is returned:

```lua
if type(node) == "table" then
  node = node[#node]
end
```

This matches the previous single-node behavior. The existing `all = false` workaround in the `iter_matches` call (from #407) is no longer sufficient with Neovim 0.12.

## Test

Verified on **Neovim v0.12.3** — opening any file no longer produces treesitter backend errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)